### PR TITLE
fix: CI の pnpm install エラーを修正（allowBuilds を true に設定）

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 allowBuilds:
-  esbuild: set this to true or false
-  lefthook: set this to true or false
-  sharp: set this to true or false
+  esbuild: true
+  lefthook: true
+  sharp: true
 minimumReleaseAgeExclude:
   - '@emulators/adapter-next@0.6.1'
   - '@emulators/core@0.6.1'


### PR DESCRIPTION
## 問題

`pnpm install --frozen-lockfile` が `ERR_PNPM_IGNORED_BUILDS` エラーで exit code 1 になり、CI が全ジョブで失敗していた。

## 原因

`pnpm-workspace.yaml` の `allowBuilds` の値が `"set this to true or false"` というプレースホルダーのままで、pnpm v11 の supply-chain policy がビルドスクリプトを持つパッケージ（`esbuild`, `lefthook`, `sharp`）の実行を拒否していた。

ローカルでは `pnpm approve-builds` を以前に実行済みでグローバル設定に残っていたため問題が顕在化していなかった。

## 修正

`pnpm-workspace.yaml` の `allowBuilds` を `true` に設定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)