### PR TITLE
feat: M3 スライスB ノードの SFD 化編集 UI（kind/式/値）

### DIFF
--- a/src/app/(main)/projects/[projectId]/_actions.ts
+++ b/src/app/(main)/projects/[projectId]/_actions.ts
@@ -3,8 +3,15 @@
 import { and, eq, ne } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { db } from "@/db";
-import { edges, nodes, type Polarity, projects } from "@/db/schema";
+import {
+  edges,
+  type NodeKind,
+  nodes,
+  type Polarity,
+  projects,
+} from "@/db/schema";
 import { normalizeName } from "@/lib/diagram/apply-diff";
+import { validateExpressionStructure } from "@/lib/diagram/simulate";
 import { requireSession } from "@/lib/session";
 
 /** プロジェクトの所有を確認して返す。他人のものなら null */
@@ -59,7 +66,19 @@ export async function updateNodePosition(
 export async function updateNode(
   projectId: string,
   nodeId: string,
-  input: { name: string; memo: string; unit: string },
+  input: {
+    name: string;
+    memo: string;
+    unit: string;
+    /** SFD 役割。null = 未分類（CLD のまま） */
+    kind: NodeKind | null;
+    /** flow / auxiliary の式 */
+    expression: string;
+    /** stock の初期値。空欄は null */
+    initialValue: number | null;
+    /** constant の値。空欄は null */
+    value: number | null;
+  },
 ) {
   const project = await getOwnedProject(projectId);
   const name = input.name.trim();
@@ -74,12 +93,41 @@ export async function updateNode(
     return { ok: false as const, error: `変数「${name}」は既にあります` };
   }
 
+  // kind に応じて保存する列だけを残し、無関係な列は null 化する（残留防止）。
+  const { kind } = input;
+  const expr = input.expression.trim();
+  let expression: string | null = null;
+  let initialValue: number | null = null;
+  let value: number | null = null;
+
+  if (kind === "stock") {
+    initialValue = input.initialValue;
+  } else if (kind === "constant") {
+    value = input.value;
+  } else if (kind === "flow" || kind === "auxiliary") {
+    if (expr) {
+      const err = validateExpressionStructure(expr);
+      if (err) return { ok: false as const, error: err.message };
+      expression = expr;
+    }
+  }
+  if (initialValue !== null && !Number.isFinite(initialValue)) {
+    return { ok: false as const, error: "初期値は数値で入力してください" };
+  }
+  if (value !== null && !Number.isFinite(value)) {
+    return { ok: false as const, error: "定数値は数値で入力してください" };
+  }
+
   await db
     .update(nodes)
     .set({
       name,
       memo: input.memo.trim() || null,
       unit: input.unit.trim() || null,
+      kind,
+      expression,
+      initialValue,
+      value,
     })
     .where(and(eq(nodes.id, nodeId), eq(nodes.projectId, projectId)));
   await touchProject(projectId);

--- a/src/app/(main)/projects/[projectId]/_components/inspector-panel.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/inspector-panel.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import type { Polarity } from "@/db/schema";
+import type { NodeKind, Polarity } from "@/db/schema";
 import type { Diagram, DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
 import { cn } from "@/lib/utils";
 import { deleteEdge, deleteNode, updateEdge, updateNode } from "../_actions";
@@ -61,6 +61,14 @@ export function InspectorPanel({
   );
 }
 
+const KIND_OPTIONS: { value: NodeKind | null; label: string }[] = [
+  { value: null, label: "未分類" },
+  { value: "stock", label: "ストック" },
+  { value: "flow", label: "フロー" },
+  { value: "auxiliary", label: "補助変数" },
+  { value: "constant", label: "定数" },
+];
+
 function NodeForm({
   projectId,
   node,
@@ -71,13 +79,27 @@ function NodeForm({
   onClose: () => void;
 }) {
   const [name, setName] = useState(node.name);
+  const [kind, setKind] = useState<NodeKind | null>(node.kind);
+  const [expression, setExpression] = useState(node.expression ?? "");
+  const [initialValue, setInitialValue] = useState(
+    node.initialValue?.toString() ?? "",
+  );
+  const [value, setValue] = useState(node.value?.toString() ?? "");
   const [memo, setMemo] = useState(node.memo ?? "");
   const [unit, setUnit] = useState(node.unit ?? "");
   const [isPending, startTransition] = useTransition();
 
   const save = () => {
     startTransition(async () => {
-      const result = await updateNode(projectId, node.id, { name, memo, unit });
+      const result = await updateNode(projectId, node.id, {
+        name,
+        memo,
+        unit,
+        kind,
+        expression,
+        initialValue: initialValue.trim() === "" ? null : Number(initialValue),
+        value: value.trim() === "" ? null : Number(value),
+      });
       if (result.ok) {
         toast.success("変数を更新しました");
       } else {
@@ -111,6 +133,57 @@ function NodeForm({
         />
       </div>
       <div className="space-y-1.5">
+        <Label>役割</Label>
+        <div className="flex flex-wrap gap-1.5">
+          {KIND_OPTIONS.map((opt) => (
+            <KindButton
+              key={opt.label}
+              label={opt.label}
+              active={kind === opt.value}
+              onClick={() => setKind(opt.value)}
+            />
+          ))}
+        </div>
+      </div>
+      {kind === "stock" && (
+        <div className="space-y-1.5">
+          <Label htmlFor="node-initial">初期値</Label>
+          <Input
+            id="node-initial"
+            type="number"
+            value={initialValue}
+            onChange={(e) => setInitialValue(e.target.value)}
+            placeholder="例: 30"
+          />
+        </div>
+      )}
+      {(kind === "flow" || kind === "auxiliary") && (
+        <div className="space-y-1.5">
+          <Label htmlFor="node-expr">式</Label>
+          <Input
+            id="node-expr"
+            value={expression}
+            onChange={(e) => setExpression(e.target.value)}
+            placeholder="例: 疲労/100"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            他の変数名と + − * / で書く
+          </p>
+        </div>
+      )}
+      {kind === "constant" && (
+        <div className="space-y-1.5">
+          <Label htmlFor="node-value">定数値</Label>
+          <Input
+            id="node-value"
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="例: 0.1"
+          />
+        </div>
+      )}
+      <div className="space-y-1.5">
         <Label htmlFor="node-memo">メモ</Label>
         <Textarea
           id="node-memo"
@@ -131,6 +204,31 @@ function NodeForm({
       </div>
       <FormFooter isPending={isPending} onSave={save} onDelete={remove} />
     </div>
+  );
+}
+
+function KindButton({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md border px-2 py-1 font-serif text-xs transition-colors",
+        active
+          ? "border-ink bg-ink/10 text-ink"
+          : "text-muted-foreground hover:bg-accent",
+      )}
+    >
+      {label}
+    </button>
   );
 }
 

--- a/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
@@ -7,8 +7,17 @@ import { useHighlight } from "./highlight-context";
 
 export type VariableNodeData = { node: DiagramNode };
 
+/** kind バッジの表示ラベル。未分類（null）は出さない */
+const KIND_LABELS: Record<NonNullable<DiagramNode["kind"]>, string> = {
+  stock: "ストック",
+  flow: "フロー",
+  auxiliary: "補助変数",
+  constant: "定数",
+};
+
 export function VariableNode({ data, selected }: NodeProps) {
   const { node } = data as VariableNodeData;
+  const kindLabel = node.kind ? KIND_LABELS[node.kind] : null;
   const highlight = useHighlight();
   const emphasized = highlight?.nodeIds.has(node.id) ?? false;
   const dimmed = highlight !== null && !highlight.nodeIds.has(node.id);
@@ -30,6 +39,11 @@ export function VariableNode({ data, selected }: NodeProps) {
           className="!opacity-0 !pointer-events-none"
         />
         <div className="max-w-40 text-center">
+          {kindLabel && (
+            <span className="mb-0.5 block text-[9px] tracking-wide text-muted-foreground">
+              {kindLabel}
+            </span>
+          )}
           <span className="font-serif text-sm leading-snug">{node.name}</span>
           {node.unit && (
             <span className="mt-0.5 block text-[10px] text-muted-foreground">

--- a/src/lib/diagram/simulate.test.ts
+++ b/src/lib/diagram/simulate.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type SimEdge, type SimNode, simulate } from "./simulate";
+import {
+  type SimEdge,
+  type SimNode,
+  simulate,
+  validateExpressionStructure,
+} from "./simulate";
 
 const stock = (id: string, name: string, initialValue: number): SimNode => ({
   id,
@@ -236,5 +241,38 @@ describe("simulate", () => {
     expect(result.order.indexOf("ミス率")).toBeLessThan(
       result.order.indexOf("残業時間"),
     );
+  });
+});
+
+describe("validateExpressionStructure", () => {
+  it("四則演算と変数参照は OK（null）", () => {
+    expect(validateExpressionStructure("a + b*2 - c/3")).toBeNull();
+  });
+
+  it("日本語名を含む式も構文 OK", () => {
+    expect(validateExpressionStructure("疲労/100")).toBeNull();
+    expect(validateExpressionStructure("8 + ミス率*20")).toBeNull();
+  });
+
+  it("空文字は OK（null）", () => {
+    expect(validateExpressionStructure("")).toBeNull();
+    expect(validateExpressionStructure("   ")).toBeNull();
+  });
+
+  it("関数呼び出しは disallowed", () => {
+    expect(validateExpressionStructure("sqrt(x)")?.type).toBe("disallowed");
+  });
+
+  it("べき乗など四則演算以外の演算子は disallowed", () => {
+    expect(validateExpressionStructure("2 ^ 3")?.type).toBe("disallowed");
+  });
+
+  it("構文エラーは parse", () => {
+    expect(validateExpressionStructure("1 + + *")?.type).toBe("parse");
+  });
+
+  it("参照解決はしない（未定義名でも構文が通れば OK）", () => {
+    // 保存時は参照の有無を見ない。実行時に解決する方針
+    expect(validateExpressionStructure("存在しない名前 + 1")).toBeNull();
   });
 });

--- a/src/lib/diagram/simulate.ts
+++ b/src/lib/diagram/simulate.ts
@@ -136,8 +136,11 @@ function findDisallowed(node: MathNode): string | null {
         }
         return;
       }
+      case "FunctionNode":
+        violation = "関数は使えません（四則演算と変数参照のみ）";
+        return;
       default:
-        violation = `${n.type} は使えません（四則演算と変数参照のみ）`;
+        violation = "使えない記法が含まれています（四則演算と変数参照のみ）";
     }
   });
   return violation;
@@ -150,6 +153,33 @@ function collectSymbols(node: MathNode): string[] {
     if (n.type === "SymbolNode") names.add((n as SymbolNode).name);
   });
   return [...names];
+}
+
+/**
+ * 式の構文と演算子だけを検証する（保存時の軽い検証用）。参照解決・循環チェックは
+ * しない。全識別子トークンをダミーに置換してから parse するので、参照名の有無や
+ * 定義順に依存せず、構文と whitelist（四則演算と参照のみ）だけを見る。
+ * 関数呼び出し `f(...)` は置換後も FunctionNode として残り disallowed になる。
+ * 空文字は OK（null を返す）。
+ */
+export function validateExpressionStructure(
+  expression: string,
+): SimError | null {
+  const expr = expression.trim();
+  if (!expr) return null;
+  const code = expr.replace(TOKEN_RE, () => "_x");
+  let root: MathNode;
+  try {
+    root = parse(code);
+  } catch (e) {
+    return {
+      type: "parse",
+      message: `式を解釈できません: ${(e as Error).message}`,
+    };
+  }
+  const disallowed = findDisallowed(root);
+  if (disallowed) return { type: "disallowed", message: disallowed };
+  return null;
 }
 
 type Compiled = {

--- a/tests/db/node-sfd-update.test.ts
+++ b/tests/db/node-sfd-update.test.ts
@@ -1,0 +1,123 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it } from "vitest";
+import { updateNode } from "@/app/(main)/projects/[projectId]/_actions";
+import { db } from "@/db";
+import { nodes } from "@/db/schema";
+import { createProject, createUser } from "./factories";
+
+/** updateNode を呼べるようにセッションを差し込み、project と node を用意する */
+async function setup() {
+  const user = await createUser();
+  const project = await createProject(user.id);
+  (globalThis as { __mockSession?: unknown }).__mockSession = {
+    user: { id: user.id },
+  };
+  const [node] = await db
+    .insert(nodes)
+    .values({ projectId: project.id, name: "量" })
+    .returning();
+  return { projectId: project.id, nodeId: node.id };
+}
+
+const base = { name: "量", memo: "", unit: "" };
+
+async function readNode(nodeId: string) {
+  return db.query.nodes.findFirst({ where: eq(nodes.id, nodeId) });
+}
+
+describe("updateNode の kind 別正規化", () => {
+  beforeEach(() => {
+    (globalThis as { __mockSession?: unknown }).__mockSession = null;
+  });
+
+  it("stock では initialValue だけ残り、式・定数値は null 化される", async () => {
+    const { projectId, nodeId } = await setup();
+    const result = await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "stock",
+      expression: "a+b",
+      initialValue: 5,
+      value: 9,
+    });
+    expect(result.ok).toBe(true);
+    const node = await readNode(nodeId);
+    expect(node?.kind).toBe("stock");
+    expect(node?.initialValue).toBe(5);
+    expect(node?.expression).toBeNull();
+    expect(node?.value).toBeNull();
+  });
+
+  it("stock → flow に変えると旧 initialValue が消え expression が入る", async () => {
+    const { projectId, nodeId } = await setup();
+    await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "stock",
+      expression: "",
+      initialValue: 5,
+      value: null,
+    });
+    await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "flow",
+      expression: "a*2",
+      initialValue: 5,
+      value: null,
+    });
+    const node = await readNode(nodeId);
+    expect(node?.kind).toBe("flow");
+    expect(node?.expression).toBe("a*2");
+    expect(node?.initialValue).toBeNull();
+    expect(node?.value).toBeNull();
+  });
+
+  it("初期値の空欄（null）は 0 ではなく null として保存される", async () => {
+    const { projectId, nodeId } = await setup();
+    await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "stock",
+      expression: "",
+      initialValue: null,
+      value: null,
+    });
+    const node = await readNode(nodeId);
+    expect(node?.initialValue).toBeNull();
+  });
+
+  it("未分類（kind=null）では 3 列とも null 化される", async () => {
+    const { projectId, nodeId } = await setup();
+    await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "constant",
+      expression: "",
+      initialValue: null,
+      value: 7,
+    });
+    await updateNode(projectId, nodeId, {
+      ...base,
+      kind: null,
+      expression: "",
+      initialValue: null,
+      value: 7,
+    });
+    const node = await readNode(nodeId);
+    expect(node?.kind).toBeNull();
+    expect(node?.expression).toBeNull();
+    expect(node?.initialValue).toBeNull();
+    expect(node?.value).toBeNull();
+  });
+
+  it("flow に不正な式（関数）を渡すと保存されずエラーを返す", async () => {
+    const { projectId, nodeId } = await setup();
+    const result = await updateNode(projectId, nodeId, {
+      ...base,
+      kind: "flow",
+      expression: "sqrt(x)",
+      initialValue: null,
+      value: null,
+    });
+    expect(result.ok).toBe(false);
+    const node = await readNode(nodeId);
+    expect(node?.expression).toBeNull();
+    expect(node?.kind).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

M3 スライス B。CLD のノードに SFD 役割（kind）と数値的意味（式 / 初期値 / 定数値）を**手動で**与えられる編集 UI。シミュレーション実行・グラフ描画はスライス C。

> [!NOTE]
> スライス A（[#2](https://github.com/mittsmasa/interlink/pull/2)）の上に積んだ PR。ベースは `feat/m3-sim-core`。#2 マージ後に main へ自動で張り替わります。

## 変更内容

### インスペクタ（`NodeForm`）
- 「役割」セグメントボタン（未分類 / ストック / フロー / 補助変数 / 定数）を追加。既存 `PolarityButton` と同じ方式で、新規 UI ライブラリは入れない
- 役割に応じた条件付き入力欄: ストック→初期値 / フロー・補助→式 / 定数→定数値 / 未分類→なし

### `updateNode` action
- kind / expression / initialValue / value を受け、**kind 別に関連列だけ保存し無関係列は null 化**（データ残留を防ぐ）
- flow/auxiliary の式は保存時に**構文 + whitelist 検証**（`simulate.ts` のパーサ再利用）。未定義参照・循環は実行時（スライス C）に委ねる
- 数値は**空欄=null**（`Number("")===0` を踏まず暗黙の 0 化を回避）

### `simulate.ts`
- `validateExpressionStructure` を export 追加（全識別子をダミー置換 → parse → whitelist。参照解決しない）
- 拒否メッセージをユーザー向け文言に（`FunctionNode` 等の AST 内部名を出さない）

### `variable-node.tsx`
- kind バッジを表示（未分類は非表示）。`.ink-in` の opacity/transform 罠を避け内側カードの子に配置

## テスト・確認
- `simulate.test.ts`: `validateExpressionStructure` 単体（四則演算 OK / 関数・べき乗 NG / 日本語名 OK / 構文エラーは parse）
- `tests/db/node-sfd-update.test.ts`: `updateNode` の kind 別正規化（stock↔flow の列入れ替え、空欄=null、未分類で全 null、不正式の拒否）
- `pnpm check` exit 0 / `pnpm test` 13 files・111 tests 全 PASS
- **ui-verify（実ブラウザ）**: 役割選択→欄出し分け→保存→成功トースト→ノードにバッジ、フロー+`sqrt(x)`→エラートースト（保存されない）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)