### PR TITLE
feat: M3 スライスC シミュレーション実行 + 時系列グラフ描画

### DIFF
--- a/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
@@ -26,6 +26,7 @@ import { type Highlight, HighlightContext } from "./highlight-context";
 import { InspectorPanel } from "./inspector-panel";
 import { computePositions } from "./layout-diagram";
 import { LoopBadges } from "./loop-badges";
+import { SimulationPanel } from "./simulation-panel";
 import { VariableNode } from "./variable-node";
 import { VerificationPanel } from "./verification-panel";
 
@@ -194,6 +195,8 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
           onSelectFinding={selectFinding}
         />
       )}
+
+      {diagram.nodes.length > 0 && <SimulationPanel diagram={diagram} />}
 
       {diagram.nodes.length === 0 && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">

--- a/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { SimSnapshot } from "@/lib/diagram/simulate";
+import {
+  type ChartDims,
+  colorForIndex,
+  computeChartGeometry,
+  SERIES_PALETTE,
+} from "./sim-chart-geometry";
+
+const DIMS: ChartDims = {
+  width: 360,
+  height: 200,
+  padding: { top: 12, right: 12, bottom: 24, left: 44 },
+};
+// area: left 44 / top 12 / right 348 / bottom 176
+
+describe("computeChartGeometry", () => {
+  it("既知 series を枠に収まる座標へ写す（端点が角に来る）", () => {
+    const series: SimSnapshot[] = [
+      { t: 0, 疲労: 30 },
+      { t: 1, 疲労: 34 },
+      { t: 2, 疲労: 38 },
+      { t: 3, 疲労: 42 },
+    ];
+    const geo = computeChartGeometry(series, ["疲労"], DIMS);
+
+    expect(geo.xMax).toBe(3);
+    expect(geo.yMin).toBe(30);
+    expect(geo.yMax).toBe(42);
+
+    const pts = geo.lines[0].points;
+    expect(pts).toHaveLength(4);
+    // t=0 かつ最小値 → 左下の角
+    expect(pts[0]).toEqual({ x: 44, y: 176 });
+    // t=3 かつ最大値 → 右上の角
+    expect(pts[3]).toEqual({ x: 348, y: 12 });
+    expect(geo.lines[0].color).toBe(SERIES_PALETTE[0]);
+  });
+
+  it("空 series でも破綻せず空 points を返す", () => {
+    const geo = computeChartGeometry([], ["疲労"], DIMS);
+    expect(geo.xMax).toBe(0);
+    expect(geo.yMin).toBe(0);
+    expect(geo.yMax).toBe(1);
+    expect(geo.lines[0].points).toEqual([]);
+  });
+
+  it("全値同一（y 幅 0）でも ±1 に広げて中央に線を引く", () => {
+    const series: SimSnapshot[] = [
+      { t: 0, 量: 5 },
+      { t: 1, 量: 5 },
+      { t: 2, 量: 5 },
+    ];
+    const geo = computeChartGeometry(series, ["量"], DIMS);
+    expect(geo.yMin).toBe(4);
+    expect(geo.yMax).toBe(6);
+    // 値 5 は範囲 [4,6] の中央 → プロット領域の中央 y
+    const midY = (12 + 176) / 2;
+    for (const p of geo.lines[0].points) {
+      expect(p.y).toBeCloseTo(midY, 5);
+    }
+  });
+
+  it("単一ステップ（xMax=0）でも x が左端に揃う", () => {
+    const geo = computeChartGeometry([{ t: 0, 量: 10 }], ["量"], DIMS);
+    expect(geo.xMax).toBe(0);
+    expect(geo.lines[0].points).toHaveLength(1);
+    expect(geo.lines[0].points[0].x).toBe(44);
+  });
+
+  it("複数系列の色割り当てが名前順で決定的", () => {
+    const series: SimSnapshot[] = [{ t: 0, a: 1, b: 2, c: 3 }];
+    const geo1 = computeChartGeometry(series, ["a", "b", "c"], DIMS);
+    const geo2 = computeChartGeometry(series, ["a", "b", "c"], DIMS);
+    expect(geo1.lines.map((l) => l.color)).toEqual([
+      colorForIndex(0),
+      colorForIndex(1),
+      colorForIndex(2),
+    ]);
+    expect(geo1.lines.map((l) => l.color)).toEqual(
+      geo2.lines.map((l) => l.color),
+    );
+  });
+});

--- a/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.ts
@@ -1,0 +1,111 @@
+import type { SimSnapshot } from "@/lib/diagram/simulate";
+
+/**
+ * 系列の色パレット。彩度を抑えた中間トーンで、明背景（和紙）でも暗背景でも読める。
+ * 名前順の index で決定的に割り当てる（テストで固定できるよう純粋に保つ）。
+ */
+export const SERIES_PALETTE = [
+  "#c8553d", // vermilion 寄り（アプリのアクセント色調）
+  "#4a5a8a", // indigo
+  "#3f7d72", // teal
+  "#b07d34", // amber
+  "#8a5a7a", // plum
+  "#5a6670", // slate
+] as const;
+
+export function colorForIndex(index: number): string {
+  return SERIES_PALETTE[index % SERIES_PALETTE.length];
+}
+
+export type ChartPoint = { x: number; y: number };
+
+export type ChartLine = {
+  name: string;
+  color: string;
+  points: ChartPoint[];
+};
+
+export type ChartDims = {
+  width: number;
+  height: number;
+  /** プロット領域の余白（軸ラベル/凡例の場所を確保） */
+  padding: { top: number; right: number; bottom: number; left: number };
+};
+
+export type ChartGeometry = {
+  lines: ChartLine[];
+  /** プロット領域の SVG 矩形 */
+  area: { left: number; top: number; right: number; bottom: number };
+  yMin: number;
+  yMax: number;
+  xMax: number;
+  /** y 軸の目盛り（値と SVG y 座標） */
+  yTicks: { value: number; y: number }[];
+  width: number;
+  height: number;
+};
+
+/**
+ * シミュレーション結果（series）から SVG 折れ線の座標を決定的に計算する純粋関数。
+ *
+ * - x は t（0..steps-1）を等間隔で割り付ける。steps=1（xMax=0）でも破綻しない
+ * - y は全系列の min/max にスケール。全値同一（範囲 0）でも ±1 に広げて中央に線を引く
+ * - 色は names の順番（index）で `SERIES_PALETTE` から決定的に割り当てる
+ *
+ * names は描画対象のノード名（series のキー）。空 series / 空 names でも安全に空 geometry を返す。
+ */
+export function computeChartGeometry(
+  series: SimSnapshot[],
+  names: string[],
+  dims: ChartDims,
+): ChartGeometry {
+  const { width, height, padding } = dims;
+  const area = {
+    left: padding.left,
+    top: padding.top,
+    right: width - padding.right,
+    bottom: height - padding.bottom,
+  };
+
+  const xMax = series.length > 0 ? series.length - 1 : 0;
+
+  // 全系列・全ステップを走査して y の範囲を求める
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+  for (const snap of series) {
+    for (const name of names) {
+      const v = snap[name];
+      if (typeof v === "number" && Number.isFinite(v)) {
+        if (v < yMin) yMin = v;
+        if (v > yMax) yMax = v;
+      }
+    }
+  }
+  // 値が 1 つも無い / 範囲ゼロのときの保険
+  if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+    yMin = 0;
+    yMax = 1;
+  } else if (yMin === yMax) {
+    yMin -= 1;
+    yMax += 1;
+  }
+
+  const xFor = (t: number): number =>
+    xMax === 0 ? area.left : area.left + (t / xMax) * (area.right - area.left);
+  const yFor = (v: number): number =>
+    area.bottom - ((v - yMin) / (yMax - yMin)) * (area.bottom - area.top);
+
+  const lines: ChartLine[] = names.map((name, index) => ({
+    name,
+    color: colorForIndex(index),
+    points: series.map((snap, t) => ({ x: xFor(t), y: yFor(snap[name]) })),
+  }));
+
+  const yTicks = [
+    { value: yMax, y: yFor(yMax) },
+    { value: (yMin + yMax) / 2, y: yFor((yMin + yMax) / 2) },
+    { value: yMin, y: yFor(yMin) },
+  ];
+
+  return { lines, area, yMin, yMax, xMax, yTicks, width, height };
+}

--- a/src/app/(main)/projects/[projectId]/_components/sim-chart.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart.tsx
@@ -1,0 +1,133 @@
+import type { SimSnapshot } from "@/lib/diagram/simulate";
+import {
+  type ChartDims,
+  colorForIndex,
+  computeChartGeometry,
+} from "./sim-chart-geometry";
+
+const DIMS: ChartDims = {
+  width: 360,
+  height: 200,
+  padding: { top: 12, right: 12, bottom: 24, left: 44 },
+};
+
+/** 目盛り値を読みやすい桁に丸める（整数なら整数、端数は小数 2 桁） */
+function formatTick(value: number): string {
+  if (Number.isInteger(value)) return String(value);
+  return value.toFixed(2);
+}
+
+type SimChartProps = {
+  series: SimSnapshot[];
+  /** 描画する系列（ノード名）。色は配列順で決まる */
+  names: string[];
+};
+
+/**
+ * シミュレーション結果の多系列折れ線グラフ。座標計算は `computeChartGeometry`（純粋）に委ね、
+ * ここは SVG とHTML 凡例の描画だけを担う presentational コンポーネント。
+ */
+export function SimChart({ series, names }: SimChartProps) {
+  const geo = computeChartGeometry(series, names, DIMS);
+  const { area } = geo;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <svg
+        viewBox={`0 0 ${geo.width} ${geo.height}`}
+        className="h-auto w-full"
+        role="img"
+        aria-label="シミュレーション結果の時系列グラフ"
+      >
+        {/* y 軸の目盛り線とラベル */}
+        {geo.yTicks.map((tick) => (
+          <g key={`y-${tick.value}`}>
+            <line
+              x1={area.left}
+              y1={tick.y}
+              x2={area.right}
+              y2={tick.y}
+              stroke="var(--grid-line)"
+              strokeWidth={1}
+            />
+            <text
+              x={area.left - 6}
+              y={tick.y}
+              textAnchor="end"
+              dominantBaseline="middle"
+              className="fill-muted-foreground text-[9px]"
+            >
+              {formatTick(tick.value)}
+            </text>
+          </g>
+        ))}
+
+        {/* x 軸の基線と両端の t ラベル */}
+        <line
+          x1={area.left}
+          y1={area.bottom}
+          x2={area.right}
+          y2={area.bottom}
+          stroke="var(--grid-line)"
+          strokeWidth={1}
+        />
+        <text
+          x={area.left}
+          y={area.bottom + 14}
+          textAnchor="start"
+          className="fill-muted-foreground text-[9px]"
+        >
+          t=0
+        </text>
+        <text
+          x={area.right}
+          y={area.bottom + 14}
+          textAnchor="end"
+          className="fill-muted-foreground text-[9px]"
+        >
+          t={geo.xMax}
+        </text>
+
+        {/* 各系列の折れ線（1 点のみのときは点で表す） */}
+        {geo.lines.map((line) =>
+          line.points.length === 1 ? (
+            <circle
+              key={line.name}
+              cx={line.points[0].x}
+              cy={line.points[0].y}
+              r={2.5}
+              fill={line.color}
+            />
+          ) : (
+            <polyline
+              key={line.name}
+              points={line.points.map((p) => `${p.x},${p.y}`).join(" ")}
+              fill="none"
+              stroke={line.color}
+              strokeWidth={1.75}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          ),
+        )}
+      </svg>
+
+      {/* 凡例（折り返し可能な HTML） */}
+      <ul className="flex flex-wrap gap-x-3 gap-y-1">
+        {names.map((name, index) => (
+          <li
+            key={name}
+            className="flex items-center gap-1.5 text-muted-foreground text-xs"
+          >
+            <span
+              aria-hidden
+              className="inline-block size-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: colorForIndex(index) }}
+            />
+            {name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(main)/projects/[projectId]/_components/sim-inputs.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-inputs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
+import { canSimulate, toSimEdges, toSimNodes } from "./sim-inputs";
+
+/** テスト用に DiagramNode を最小プロパティから組む */
+function node(
+  partial: Partial<DiagramNode> & { id: string; name: string },
+): DiagramNode {
+  return {
+    projectId: "p1",
+    memo: null,
+    unit: null,
+    kind: null,
+    expression: null,
+    initialValue: null,
+    value: null,
+    x: null,
+    y: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...partial,
+  } as DiagramNode;
+}
+
+function edge(partial: Partial<DiagramEdge> & { id: string }): DiagramEdge {
+  return {
+    projectId: "p1",
+    sourceNodeId: "a",
+    targetNodeId: "b",
+    polarity: "+",
+    hasDelay: false,
+    rationale: "r",
+    createdAt: 0,
+    ...partial,
+  } as DiagramEdge;
+}
+
+describe("toSimNodes", () => {
+  it("kind=null（未分類）のノードは除外される", () => {
+    const result = toSimNodes([
+      node({ id: "1", name: "未分類", kind: null }),
+      node({ id: "2", name: "疲労", kind: "stock", initialValue: 30 }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "2", name: "疲労", kind: "stock" });
+  });
+
+  it("kind 付きノードは field をそのまま写す", () => {
+    const result = toSimNodes([
+      node({
+        id: "3",
+        name: "回復",
+        kind: "flow",
+        expression: "疲労 / 10",
+        initialValue: null,
+        value: null,
+      }),
+    ]);
+    expect(result[0]).toEqual({
+      id: "3",
+      name: "回復",
+      kind: "flow",
+      expression: "疲労 / 10",
+      initialValue: null,
+      value: null,
+    });
+  });
+});
+
+describe("toSimEdges", () => {
+  it("polarity（+/-）をそのまま写す", () => {
+    const result = toSimEdges([
+      edge({ id: "e1", sourceNodeId: "a", targetNodeId: "b", polarity: "+" }),
+      edge({ id: "e2", sourceNodeId: "c", targetNodeId: "d", polarity: "-" }),
+    ]);
+    expect(result).toEqual([
+      { sourceNodeId: "a", targetNodeId: "b", polarity: "+" },
+      { sourceNodeId: "c", targetNodeId: "d", polarity: "-" },
+    ]);
+  });
+});
+
+describe("canSimulate", () => {
+  it("stock を含むと true", () => {
+    expect(
+      canSimulate(
+        toSimNodes([
+          node({ id: "1", name: "量", kind: "stock", initialValue: 0 }),
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("stock を含まないと false", () => {
+    expect(
+      canSimulate(
+        toSimNodes([
+          node({ id: "1", name: "率", kind: "flow", expression: "1" }),
+          node({ id: "2", name: "係数", kind: "constant", value: 2 }),
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("空（全て未分類）だと false", () => {
+    expect(
+      canSimulate(toSimNodes([node({ id: "1", name: "x", kind: null })])),
+    ).toBe(false);
+  });
+});

--- a/src/app/(main)/projects/[projectId]/_components/sim-inputs.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-inputs.ts
@@ -1,0 +1,45 @@
+import type { SimEdge, SimNode } from "@/lib/diagram/simulate";
+import type { DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
+
+/**
+ * 図のノードからシミュレーション入力（SimNode）へ写す。
+ * kind 未設定（null = CLD のまま）のノードは数値的意味を持たないので除外する。
+ * 名前は simulate 側で ASCII プレースホルダへ内部変換されるため、日本語名のまま渡してよい。
+ */
+export function toSimNodes(nodes: DiagramNode[]): SimNode[] {
+  const result: SimNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === null) continue;
+    result.push({
+      id: node.id,
+      name: node.name,
+      kind: node.kind,
+      expression: node.expression,
+      initialValue: node.initialValue,
+      value: node.value,
+    });
+  }
+  return result;
+}
+
+/**
+ * 図のエッジを SimEdge へ写す。polarity は schema 上 "+"/"-" で SimEdge とそのまま一致する。
+ * simulate 側は flow → stock のエッジだけを流入/流出として解釈するため、ここでは全エッジを
+ * 素直に渡してよい（関係ないエッジは simulate 内で無視される）。
+ */
+export function toSimEdges(edges: DiagramEdge[]): SimEdge[] {
+  return edges.map((edge) => ({
+    sourceNodeId: edge.sourceNodeId,
+    targetNodeId: edge.targetNodeId,
+    polarity: edge.polarity,
+  }));
+}
+
+/**
+ * 実行ボタンの出し分け用の軽い判定。stock が 1 つも無ければシミュレーションは成立しない
+ * （時間発展する量が無い）。厳密な妥当性（式の参照解決・循環・missing-field 等）は
+ * simulate に委ね、ここでは「押せる状態かどうか」だけを大まかに見る。
+ */
+export function canSimulate(simNodes: SimNode[]): boolean {
+  return simNodes.some((node) => node.kind === "stock");
+}

--- a/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { CaretDownIcon, ChartLineIcon, PlayIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type SimResult, simulate } from "@/lib/diagram/simulate";
+import type { Diagram } from "@/lib/queries/diagrams";
+import { cn } from "@/lib/utils";
+import { SimChart } from "./sim-chart";
+import { canSimulate, toSimEdges, toSimNodes } from "./sim-inputs";
+
+type SimulationPanelProps = {
+  diagram: Diagram;
+};
+
+/**
+ * シミュレーション実行 + 時系列グラフのフローティングパネル。キャンバス左下に折りたたみで置く
+ * （構造パネルは左上、inspector は右上）。simulate はクライアントで呼ぶ純粋関数で、結果は保存
+ * しない（ループ/lint と同思想）。
+ */
+export function SimulationPanel({ diagram }: SimulationPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [dt, setDt] = useState("1");
+  const [steps, setSteps] = useState("20");
+  const [result, setResult] = useState<SimResult | null>(null);
+
+  const { simNodes, simEdges, names, runnable } = useMemo(() => {
+    const simNodes = toSimNodes(diagram.nodes);
+    return {
+      simNodes,
+      simEdges: toSimEdges(diagram.edges),
+      names: simNodes.map((n) => n.name),
+      runnable: canSimulate(simNodes),
+    };
+  }, [diagram]);
+
+  const run = () => {
+    // 数値変換は simulate 側の config 検証に委ねる（空欄→0, 不正→NaN はそこで
+    // invalid-config として人間可読メッセージになる）
+    setResult(
+      simulate(simNodes, simEdges, { dt: Number(dt), steps: Number(steps) }),
+    );
+  };
+
+  return (
+    <div className="absolute bottom-3 left-3 flex w-80 flex-col-reverse">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-fit items-center gap-2 rounded-lg border bg-card/95 px-3 py-1.5 shadow-md backdrop-blur-sm transition-colors hover:bg-accent"
+        aria-expanded={open}
+      >
+        <ChartLineIcon className="size-4 text-muted-foreground" />
+        <span className="font-serif text-sm">シミュレーション</span>
+        <CaretDownIcon
+          className={cn(
+            "size-3 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="ink-in mb-2 space-y-3 rounded-lg border bg-card/95 p-4 shadow-md backdrop-blur-sm">
+          <div className="flex items-end gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="sim-dt" className="text-muted-foreground text-xs">
+                dt
+              </Label>
+              <Input
+                id="sim-dt"
+                type="number"
+                step="0.1"
+                value={dt}
+                onChange={(e) => setDt(e.target.value)}
+                className="h-8 w-16"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label
+                htmlFor="sim-steps"
+                className="text-muted-foreground text-xs"
+              >
+                steps
+              </Label>
+              <Input
+                id="sim-steps"
+                type="number"
+                step="1"
+                value={steps}
+                onChange={(e) => setSteps(e.target.value)}
+                className="h-8 w-20"
+              />
+            </div>
+            <Button
+              size="sm"
+              className="ml-auto gap-1.5"
+              disabled={!runnable}
+              onClick={run}
+            >
+              <PlayIcon className="size-3.5" weight="fill" />
+              実行
+            </Button>
+          </div>
+
+          <div className="min-h-24">
+            {!runnable ? (
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                ストックに初期値、フロー/補助変数に式を設定すると実行できます。
+              </p>
+            ) : result === null ? (
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                dt と steps
+                を決めて「実行」すると、各変数の時間変化が描かれます。
+              </p>
+            ) : result.ok ? (
+              <SimChart series={result.series} names={names} />
+            ) : (
+              <p className="text-(--vermilion) text-sm leading-relaxed">
+                {result.error.message}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
@@ -7,17 +7,54 @@ import { useHighlight } from "./highlight-context";
 
 export type VariableNodeData = { node: DiagramNode };
 
+type Kind = NonNullable<DiagramNode["kind"]>;
+
 /** kind バッジの表示ラベル。未分類（null）は出さない */
-const KIND_LABELS: Record<NonNullable<DiagramNode["kind"]>, string> = {
+const KIND_LABELS: Record<Kind, string> = {
   stock: "ストック",
   flow: "フロー",
   auxiliary: "補助変数",
   constant: "定数",
 };
 
+/**
+ * kind ごとの輪郭（System Dynamics の記法に寄せる）。
+ * - stock: 角ばった四角（溜まる量の器）。線を太く
+ * - flow: 弁（バルブ）を示す。箱は控えめにし ValveMark を添える
+ * - auxiliary: 丸（補助変数）
+ * - constant: 破線の丸（固定パラメータ）
+ * - null（未分類）: 従来の角丸カード
+ */
+const KIND_SHAPE: Record<Kind, string> = {
+  stock: "rounded-none border-2",
+  flow: "rounded-md",
+  auxiliary: "rounded-full px-5",
+  constant: "rounded-full border-dashed px-5",
+};
+
+/** フローの弁（バルブ）記号。蝶ネクタイ型の三角 2 つで「流量を絞る弁」を表す */
+function ValveMark() {
+  return (
+    <svg
+      viewBox="0 0 16 10"
+      className="mx-auto mb-0.5 block h-2.5 w-4"
+      aria-hidden
+    >
+      <title>弁</title>
+      <path
+        d="M1 1 L8 5 L1 9 Z M15 1 L8 5 L15 9 Z"
+        className="fill-card stroke-muted-foreground"
+        strokeWidth={1}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function VariableNode({ data, selected }: NodeProps) {
   const { node } = data as VariableNodeData;
-  const kindLabel = node.kind ? KIND_LABELS[node.kind] : null;
+  const kind = node.kind;
+  const kindLabel = kind ? KIND_LABELS[kind] : null;
   const highlight = useHighlight();
   const emphasized = highlight?.nodeIds.has(node.id) ?? false;
   const dimmed = highlight !== null && !highlight.nodeIds.has(node.id);
@@ -28,7 +65,8 @@ export function VariableNode({ data, selected }: NodeProps) {
     >
       <div
         className={cn(
-          "ink-in rounded-md border bg-card px-4 py-2 shadow-sm transition-shadow",
+          "ink-in border bg-card px-4 py-2 shadow-sm transition-shadow",
+          kind ? KIND_SHAPE[kind] : "rounded-md",
           (selected || emphasized) && "border-ring shadow-md",
         )}
       >
@@ -39,6 +77,7 @@ export function VariableNode({ data, selected }: NodeProps) {
           className="!opacity-0 !pointer-events-none"
         />
         <div className="max-w-40 text-center">
+          {kind === "flow" && <ValveMark />}
           {kindLabel && (
             <span className="mb-0.5 block text-[9px] tracking-wide text-muted-foreground">
               {kindLabel}


### PR DESCRIPTION
## 概要

M3（ストック&フロー + シミュレーション）の最後のピース。スライス A（計算コア `simulate.ts`）と B（kind/式/値の編集 UI）の上に、図を「動かして見る」実行 + 可視化を足す。これで編集 → 実行 → 可視化の縦の最小ループが閉じる。

**スタック PR**: base は `feat/m3-sfd-edit`（[#3](https://github.com/mittsmasa/interlink/pull/3)）。#3 がマージされると自動で main に張り替わる。

## 変更点

- キャンバス左下に折りたたみ式の「シミュレーション」パネルを追加。`dt` / `steps` を指定して実行すると、**クライアントで純粋関数 `simulate()` を呼び**（I/O なし・結果は保存しない＝ループ/lint と同思想）、各変数の時系列を**自前 SVG の折れ線グラフ + 凡例**で描く。エラーは `SimError.message` をそのまま表示
- diagram→Sim 変換（`sim-inputs.ts`）とグラフのスケール/色計算（`sim-chart-geometry.ts`）は純粋ヘルパに切り出して単体テスト。`simulate.ts` 本体は未変更
- **ノード形状を kind 別に System Dynamics 記法へ寄せて描き分け**: stock=角ばった四角（溜まる器）/ flow=弁（⋈ バルブ記号）/ auxiliary=丸 / constant=破線の丸 / 未分類=従来の角丸カード

## グラフ描画手段の判断

新規チャートライブラリ（recharts 等）は足さず**自前 SVG**を採用。多系列折れ線という素朴な要件で、和紙/ink/serif トーンに馴染ませたく、依存も最小にしたいため。将来 SFD が複雑化したら再検討。

## 検証

- `pnpm check`（biome + tsc）exit 0
- `pnpm test` 15 files / 122 tests PASS（B の 111 + 新規 11: sim-inputs / sim-chart-geometry）
- ui-verify（実ブラウザ）: 残高モデル（stock 残高 init=100 / flow 利息 式 `残高 * 0.1`）で実行 → 指数増加カーブ + 凡例を確認。steps=0 でエラー文表示。kind 別ノード形状 5 種も並べて確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)