### PR TITLE
feat: M3 スライスD AI による CLD→SFD 書き直し

### DIFF
--- a/src/lib/diagram/apply-diff.test.ts
+++ b/src/lib/diagram/apply-diff.test.ts
@@ -197,3 +197,129 @@ describe("planDiagramMutation", () => {
     expect(result.plan.updateNodes).toHaveLength(1);
   });
 });
+
+describe("planDiagramMutation（SFD 化）", () => {
+  it("新規ノードに kind:stock と initialValue を付けると createNodes に載る", () => {
+    const result = planDiagramMutation(
+      emptyDiagram,
+      diff({
+        upsertNodes: [{ name: "残高", kind: "stock", initialValue: 100 }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.createNodes[0]).toMatchObject({
+      name: "残高",
+      kind: "stock",
+      initialValue: 100,
+      expression: null,
+      value: null,
+    });
+  });
+
+  it("既存ノードへ kind だけ指定すると memo/unit 無しでも updateNodes に載る", () => {
+    const result = planDiagramMutation(
+      diagram,
+      diff({
+        upsertNodes: [{ name: "疲労", kind: "stock", initialValue: 30 }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.updateNodes[0]).toMatchObject({
+      id: "n2",
+      kind: "stock",
+      initialValue: 30,
+      expression: null,
+      value: null,
+    });
+  });
+
+  it("flow に正しい式を渡すと expression が載る", () => {
+    const result = planDiagramMutation(
+      diagram,
+      diff({
+        upsertNodes: [{ name: "疲労", kind: "flow", expression: "残高 * 0.1" }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.updateNodes[0]).toMatchObject({
+      id: "n2",
+      kind: "flow",
+      expression: "残高 * 0.1",
+      initialValue: null,
+      value: null,
+    });
+  });
+
+  it("flow に関数を含む不正な式を渡すと式は載らず warning になる", () => {
+    const result = planDiagramMutation(
+      diagram,
+      diff({
+        upsertNodes: [{ name: "疲労", kind: "flow", expression: "sqrt(x)" }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.updateNodes[0]).toMatchObject({
+      kind: "flow",
+      expression: null,
+    });
+    expect(result.plan.warnings.some((w) => w.includes("式が無効"))).toBe(true);
+  });
+
+  it("kind 別に無関係な列は正規化で null 化される", () => {
+    const result = planDiagramMutation(
+      emptyDiagram,
+      diff({
+        upsertNodes: [
+          {
+            name: "残高",
+            kind: "stock",
+            expression: "a + b",
+            initialValue: 5,
+            value: 9,
+          },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.createNodes[0]).toMatchObject({
+      kind: "stock",
+      initialValue: 5,
+      expression: null,
+      value: null,
+    });
+  });
+
+  it("kind 指定なしで式だけ来たら無視し warning にする", () => {
+    const result = planDiagramMutation(
+      diagram,
+      diff({
+        upsertNodes: [{ name: "疲労", expression: "残高 * 2" }],
+      }),
+    );
+    // 有効操作が無いので拒否（式は無視され、memo/unit/kind もない）
+    expect(result.ok).toBe(false);
+  });
+
+  it("kind:null で未分類へ戻すと 3 列とも null になる", () => {
+    const result = planDiagramMutation(
+      diagram,
+      diff({
+        upsertNodes: [{ name: "疲労", kind: null }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.plan.updateNodes[0]).toMatchObject({
+      id: "n2",
+      kind: null,
+      expression: null,
+      initialValue: null,
+      value: null,
+    });
+  });
+});

--- a/src/lib/diagram/apply-diff.ts
+++ b/src/lib/diagram/apply-diff.ts
@@ -1,4 +1,6 @@
+import type { NodeKind } from "@/db/schema";
 import type { DiagramDiff } from "./diff-schema";
+import { validateExpressionStructure } from "./simulate";
 
 type CurrentNode = { id: string; name: string };
 type CurrentEdge = { id: string; sourceNodeId: string; targetNodeId: string };
@@ -8,14 +10,27 @@ export type CurrentDiagram = {
   edges: CurrentEdge[];
 };
 
+/** kind 別に正規化済みの SFD 列。kind 指定があったノードにのみ付く */
+type SfdColumns = {
+  kind: NodeKind | null;
+  expression: string | null;
+  initialValue: number | null;
+  value: number | null;
+};
+
+type NodeFields = {
+  memo?: string;
+  unit?: string;
+} & Partial<SfdColumns>;
+
 /**
  * diff を DB 操作の計画に変換した結果。
  * createEdges のノード参照は名前のまま（新規ノードの ID が insert 時まで
  * 確定しないため）。適用側が createNodes の insert 後に名前 → ID を解決する。
  */
 export type MutationPlan = {
-  createNodes: { name: string; memo?: string; unit?: string }[];
-  updateNodes: { id: string; memo?: string; unit?: string }[];
+  createNodes: ({ name: string } & NodeFields)[];
+  updateNodes: ({ id: string } & NodeFields)[];
   deleteNodeIds: string[];
   createEdges: {
     sourceName: string;
@@ -42,6 +57,85 @@ export type PlanResult =
 /** 表記ゆれを吸収する名前の正規化（照合キー用。保存する名前は原文のまま） */
 export function normalizeName(name: string) {
   return name.trim().normalize("NFKC").toLowerCase();
+}
+
+/**
+ * diff のノードから永続化する SFD 列を kind 別に正規化する。
+ * `updateNode`（_actions）と同じ規律: kind に応じて関連列のみ残し、無関係列は null 化。
+ * - kind 未指定（undefined）: SFD 変更なし（columns は null）。式/初期値だけ来ても無視し warning
+ * - kind=null: 未分類へ戻す（3 列とも null）
+ * - stock: initialValue のみ / constant: value のみ
+ * - flow / auxiliary: expression のみ（validateExpressionStructure で検証。不正なら式 null + warning）
+ */
+function normalizeSfdFields(node: DiagramDiff["upsertNodes"][number]): {
+  columns: SfdColumns | null;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+
+  if (node.kind === undefined) {
+    if (
+      node.expression !== undefined ||
+      node.initialValue !== undefined ||
+      node.value !== undefined
+    ) {
+      warnings.push(
+        `変数「${node.name}」に役割（kind）の指定がないため、式/初期値/定数値は無視しました`,
+      );
+    }
+    return { columns: null, warnings };
+  }
+
+  const kind = node.kind;
+  if (kind === null) {
+    return {
+      columns: {
+        kind: null,
+        expression: null,
+        initialValue: null,
+        value: null,
+      },
+      warnings,
+    };
+  }
+  if (kind === "stock") {
+    return {
+      columns: {
+        kind,
+        expression: null,
+        initialValue: node.initialValue ?? null,
+        value: null,
+      },
+      warnings,
+    };
+  }
+  if (kind === "constant") {
+    return {
+      columns: {
+        kind,
+        expression: null,
+        initialValue: null,
+        value: node.value ?? null,
+      },
+      warnings,
+    };
+  }
+
+  // flow / auxiliary
+  let expression = node.expression?.trim() ? node.expression.trim() : null;
+  if (expression) {
+    const err = validateExpressionStructure(expression);
+    if (err) {
+      warnings.push(
+        `「${node.name}」の式が無効なため保存しませんでした: ${err.message}`,
+      );
+      expression = null;
+    }
+  }
+  return {
+    columns: { kind, expression, initialValue: null, value: null },
+    warnings,
+  };
 }
 
 /**
@@ -75,13 +169,27 @@ export function planDiagramMutation(
     }
     seenUpsertKeys.add(key);
 
+    const { columns: sfd, warnings: sfdWarnings } = normalizeSfdFields(node);
+    warnings.push(...sfdWarnings);
+
     const existing = nodesByKey.get(key);
     if (existing) {
-      if (node.memo !== undefined || node.unit !== undefined) {
-        updateNodes.push({ id: existing.id, memo: node.memo, unit: node.unit });
+      const hasMeta = node.memo !== undefined || node.unit !== undefined;
+      if (hasMeta || sfd) {
+        updateNodes.push({
+          id: existing.id,
+          memo: node.memo,
+          unit: node.unit,
+          ...(sfd ?? {}),
+        });
       }
     } else {
-      createNodes.push(node);
+      createNodes.push({
+        name: node.name,
+        memo: node.memo,
+        unit: node.unit,
+        ...(sfd ?? {}),
+      });
     }
   }
 

--- a/src/lib/diagram/diff-schema.ts
+++ b/src/lib/diagram/diff-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { NODE_KINDS } from "@/db/schema";
 
 /**
  * AI が出力する因果ループ図の差分。
@@ -24,11 +25,34 @@ export const diagramDiffSchema = z.object({
           .string()
           .optional()
           .describe("単位（任意。例: 時間/週、人、円）。わかる場合のみ"),
+        kind: z
+          .enum(NODE_KINDS)
+          .nullable()
+          .optional()
+          .describe(
+            "ストック&フロー化の役割。stock=溜まる量 / flow=stock を変える速度 / auxiliary=途中計算 / constant=固定パラメータ。CLD のままなら指定しない（null で未分類に戻す）",
+          ),
+        expression: z
+          .string()
+          .optional()
+          .describe(
+            "flow / auxiliary の計算式。四則演算（+ - * /）と既存の変数名のみ。関数・べき乗は不可。変数名は図にある名前を正確に書く（例: 残高 * 0.05）。stock / constant では使わない",
+          ),
+        initialValue: z
+          .number()
+          .nullable()
+          .optional()
+          .describe("stock の初期値（t=0 の量）。stock のときに付ける"),
+        value: z
+          .number()
+          .nullable()
+          .optional()
+          .describe("constant の固定値。constant のときに付ける"),
       }),
     )
     .default([])
     .describe(
-      "追加または更新する変数。同名の変数があれば memo/unit を更新する",
+      "追加または更新する変数。同名の変数があれば memo/unit を更新する。ストック&フロー化のときは kind と式/初期値/定数値も指定する",
     ),
   deleteNodes: z
     .array(z.string().min(1))

--- a/src/lib/diagram/mutate.ts
+++ b/src/lib/diagram/mutate.ts
@@ -24,9 +24,22 @@ export async function applyMutationPlan(projectId: string, plan: MutationPlan) {
         .values(plan.createNodes.map((n) => ({ ...n, projectId })));
     }
     for (const node of plan.updateNodes) {
+      // 指定された列だけ更新する（undefined の列は触らない）。SFD 列は kind 指定が
+      // あったノードにのみ含まれ、memo/unit のみの更新で既存の役割を消さない
       await tx
         .update(nodes)
-        .set({ memo: node.memo, unit: node.unit })
+        .set({
+          ...(node.memo !== undefined ? { memo: node.memo } : {}),
+          ...(node.unit !== undefined ? { unit: node.unit } : {}),
+          ...(node.kind !== undefined ? { kind: node.kind } : {}),
+          ...(node.expression !== undefined
+            ? { expression: node.expression }
+            : {}),
+          ...(node.initialValue !== undefined
+            ? { initialValue: node.initialValue }
+            : {}),
+          ...(node.value !== undefined ? { value: node.value } : {}),
+        })
         .where(eq(nodes.id, node.id));
     }
     for (const edge of plan.updateEdges) {

--- a/src/lib/prompts/interview.ts
+++ b/src/lib/prompts/interview.ts
@@ -10,7 +10,15 @@ import {
 import { type InterviewPhase, PHASE_LABELS } from "@/lib/interview/phase";
 
 type DiagramSnapshot = {
-  nodes: { name: string; memo: string | null; unit: string | null }[];
+  nodes: {
+    name: string;
+    memo: string | null;
+    unit: string | null;
+    kind?: "stock" | "flow" | "auxiliary" | "constant" | null;
+    expression?: string | null;
+    initialValue?: number | null;
+    value?: number | null;
+  }[];
   edges: {
     sourceName: string;
     targetName: string;
@@ -20,13 +28,31 @@ type DiagramSnapshot = {
   }[];
 };
 
+/** kind のプロンプト表示ラベル */
+const KIND_PROMPT_LABEL: Record<
+  NonNullable<DiagramSnapshot["nodes"][number]["kind"]>,
+  string
+> = {
+  stock: "ストック",
+  flow: "フロー",
+  auxiliary: "補助変数",
+  constant: "定数",
+};
+
 /** 現在の図をプロンプトに埋め込むテキストにする */
 export function formatDiagramForPrompt(diagram: DiagramSnapshot) {
   if (diagram.nodes.length === 0) {
     return "（まだ図はありません）";
   }
   const nodeLines = diagram.nodes.map((n) => {
-    const attrs = [n.memo, n.unit ? `単位: ${n.unit}` : null]
+    const sfd: string[] = [];
+    if (n.kind) sfd.push(`役割: ${KIND_PROMPT_LABEL[n.kind]}`);
+    if (n.kind === "stock" && n.initialValue != null)
+      sfd.push(`初期値: ${n.initialValue}`);
+    if ((n.kind === "flow" || n.kind === "auxiliary") && n.expression)
+      sfd.push(`式: ${n.expression}`);
+    if (n.kind === "constant" && n.value != null) sfd.push(`値: ${n.value}`);
+    const attrs = [n.memo, n.unit ? `単位: ${n.unit}` : null, ...sfd]
       .filter(Boolean)
       .join(" / ");
     return `- ${n.name}${attrs ? `（${attrs}）` : ""}`;
@@ -249,6 +275,17 @@ ${formatNotesForPrompt(notes)}
 - ユーザーが図の修正や追加に言及したら、即座にツールで反映する
 - ループが閉じていなければ、閉じるために足りない変数を推論で補うか、的を絞って質問する
 - ツールが ok: false や warnings を返したら、内容を踏まえて修正した diff を再送するか、ユーザーに確認する
+
+## ストック&フロー化（ユーザーが明示的に求めたときだけ）
+ユーザーが「ストック&フローにして」「SFD にして」「シミュレーションできるようにして」等と求めたら、updateDiagram で各変数に役割（kind）と数値的意味を付けて書き直す。通常の聞き取り（CLD づくり）では行わない。
+- 役割の見分け: stock=時間とともに溜まる/減る量（例: 残高、在庫、疲労、信頼）。flow=stock を増減させる速度（例: 入金、消費、回復）。auxiliary=途中の計算値。constant=変化しない固定パラメータ
+- 式（flow / auxiliary の expression）は四則演算（+ − × ÷）と既存の変数名のみ。関数やべき乗は使えない。変数名は図にある名前を正確に書く（日本語名で可。例: 残高 * 0.05）
+- stock には initialValue（初期値）、constant には value（固定値）を必ず付ける
+- stock を変化させる flow は、flow→stock のエッジを polarity 付きで張る（+ = 流入 / − = 流出）。rationale も書く
+- ストックは「ひとつ前の値」を保持するので、flow/auxiliary の式が stock を参照しても循環にならない。一方 flow/auxiliary 同士で輪を作ると循環エラーになるため、間に stock を挟む
+- **説明だけで終わらせない。必ず同じ応答の中で updateDiagram ツールを呼び、kind と式・初期値・定数値を実際に書き込む**。「更新します」と述べたら、その応答内で必ずツールを実行すること
+- ツールで反映したあとに、何をストック/フローにしたか、式が何を表すかを一言で説明し、画面左下のシミュレーションで動きを確認するよう促す
+- ツールが「式が無効」等の warning を返したら、式を四則演算に直して再送する
 
 ## 変数とリンクの品質
 - 変数は増減を語れる名詞句。動詞や方向を含めない（×「コスト増大」→ ○「コスト」）


### PR DESCRIPTION
## 概要

チャットの AI に「この因果ループ図をストック&フローにして」と頼むと、各ノードに役割（kind）・式・初期値・定数値を付与し、必要なエッジを張ってシミュレーション可能な SFD に書き直せるようにする。設計ノートの「AI が kind を提案 → ユーザー確定」を、既存 `updateDiagram` 差分パイプラインの拡張として実現。

**スタック PR**: base は `feat/m3-sim-graph`（[#4](https://github.com/mittsmasa/interlink/pull/4)）。下流（C→B→A）がマージされると自動で main に張り替わる。

## 変更点

- **`diff-schema.ts`**: `updateDiagram` の upsertNodes に `kind` / `expression` / `initialValue` / `value`（すべて任意）を追加。新ツールは足さず図操作の入口を一貫させる
- **`apply-diff.ts`**: `normalizeSfdFields` で kind 別正規化（stock→initialValue のみ等、無関係列は null 化＝`updateNode` と同規律）。式は `validateExpressionStructure`（四則演算 + 変数参照のみ、CJK 名 OK）で検証し、不正なら **式は保存せず warning**。SFD 列のみの更新でも updateNodes を積む
- **`mutate.ts`**: updateNodes の `.set` を指定列だけ更新する形に拡張（memo/unit のみの更新で既存の役割を消さない）
- **`interview.ts`**: 現在の図に kind/式も表示。「ストック&フロー化（ユーザーが求めたときだけ）」セクションを追加（役割の見分け・式の制約・flow→stock エッジ・**説明だけで終わらせず必ずツールを呼ぶ**）

安全網（全消去拒否・空 diff 拒否・参照なしエッジ除外）は温存。

## 適用の仕方

直接適用方式（既存 CLD 編集と一貫）。AI が `updateDiagram` で kind/式を直接書き込み、ユーザーは canvas（kind 別の形）・シミュレーション・インスペクタで結果を確認/手直しする。厳密な提案→確定 UI は将来スライス。

## 検証

- `pnpm check` exit 0 / `pnpm test` 15 files / 129 tests PASS（C の 122 + apply-diff SFD 7）
- ui-verify（実ブラウザ・end-to-end）: CLD（在庫モデル）でチャットに SFD 化を依頼 → AI が updateDiagram を実行し 在庫=stock(初期値100)/入荷=flow/出荷=flow(需要×0.5)/需要=auxiliary を適用 → ノードが kind 別の形に変化 → シミュレーション実行で時系列描画まで確認
- 実装中、既定モデル（gemini-2.5-flash）が「更新します」と述べつつツールを呼ばない事象を観測し、プロンプトに明示の強制を入れて解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)