### PR TITLE
feat: M3 スライスE グラフUX（拡大/可変幅/ホバー値/系列切替）

### DIFF
--- a/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.test.ts
@@ -4,6 +4,7 @@ import {
   type ChartDims,
   colorForIndex,
   computeChartGeometry,
+  nearestIndexForX,
   SERIES_PALETTE,
 } from "./sim-chart-geometry";
 
@@ -66,6 +67,16 @@ describe("computeChartGeometry", () => {
     expect(geo.xMax).toBe(0);
     expect(geo.lines[0].points).toHaveLength(1);
     expect(geo.lines[0].points[0].x).toBe(44);
+  });
+
+  it("nearestIndexForX: 端・中間・範囲外・xMax=0 を正しく扱う", () => {
+    const area = { left: 44, right: 348 };
+    expect(nearestIndexForX(44, area, 3)).toBe(0); // 左端
+    expect(nearestIndexForX(348, area, 3)).toBe(3); // 右端
+    expect(nearestIndexForX(196, area, 3)).toBe(2); // 中央 → round(1.5)=2
+    expect(nearestIndexForX(0, area, 3)).toBe(0); // 左外 → クランプ
+    expect(nearestIndexForX(9999, area, 3)).toBe(3); // 右外 → クランプ
+    expect(nearestIndexForX(200, area, 0)).toBe(0); // xMax=0
   });
 
   it("複数系列の色割り当てが名前順で決定的", () => {

--- a/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart-geometry.ts
@@ -109,3 +109,20 @@ export function computeChartGeometry(
 
   return { lines, area, yMin, yMax, xMax, yTicks, width, height };
 }
+
+/**
+ * プロット領域の SVG x 座標から最近傍のステップ index（0..xMax）を返す純粋関数。
+ * ホバー時にどの t を指しているか決めるのに使う。xMax<=0 は常に 0。範囲外はクランプ。
+ */
+export function nearestIndexForX(
+  x: number,
+  area: { left: number; right: number },
+  xMax: number,
+): number {
+  if (xMax <= 0) return 0;
+  const span = area.right - area.left;
+  if (span <= 0) return 0;
+  const ratio = (x - area.left) / span;
+  const idx = Math.round(ratio * xMax);
+  return Math.max(0, Math.min(xMax, idx));
+}

--- a/src/app/(main)/projects/[projectId]/_components/sim-chart.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/sim-chart.tsx
@@ -1,14 +1,25 @@
+"use client";
+
+import { useState } from "react";
 import type { SimSnapshot } from "@/lib/diagram/simulate";
 import {
   type ChartDims,
   colorForIndex,
   computeChartGeometry,
+  nearestIndexForX,
 } from "./sim-chart-geometry";
 
-const DIMS: ChartDims = {
+const DEFAULT_DIMS: ChartDims = {
   width: 360,
   height: 200,
   padding: { top: 12, right: 12, bottom: 24, left: 44 },
+};
+
+/** 拡大表示用の大きい寸法（軸ラベルなどが相対的に綺麗になる） */
+export const LARGE_DIMS: ChartDims = {
+  width: 760,
+  height: 420,
+  padding: { top: 16, right: 16, bottom: 32, left: 56 },
 };
 
 /** 目盛り値を読みやすい桁に丸める（整数なら整数、端数は小数 2 桁） */
@@ -21,96 +32,187 @@ type SimChartProps = {
   series: SimSnapshot[];
   /** 描画する系列（ノード名）。色は配列順で決まる */
   names: string[];
+  /** 描画寸法。既定はパネル内の小サイズ。拡大時は LARGE_DIMS を渡す */
+  dims?: ChartDims;
 };
 
 /**
  * シミュレーション結果の多系列折れ線グラフ。座標計算は `computeChartGeometry`（純粋）に委ね、
- * ここは SVG とHTML 凡例の描画だけを担う presentational コンポーネント。
+ * ここは SVG・HTML 凡例・ホバー時の値表示を担う。ホバーは最近傍の t を縦ガイド線 +
+ * ツールチップで示す。
  */
-export function SimChart({ series, names }: SimChartProps) {
-  const geo = computeChartGeometry(series, names, DIMS);
+export function SimChart({
+  series,
+  names,
+  dims = DEFAULT_DIMS,
+}: SimChartProps) {
+  const geo = computeChartGeometry(series, names, dims);
   const { area } = geo;
+  const [hover, setHover] = useState<number | null>(null);
+
+  const handleMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (geo.lines.length === 0) return;
+    const svg = e.currentTarget;
+    const ctm = svg.getScreenCTM();
+    if (!ctm) return;
+    const pt = svg.createSVGPoint();
+    pt.x = e.clientX;
+    pt.y = e.clientY;
+    const local = pt.matrixTransform(ctm.inverse());
+    setHover(nearestIndexForX(local.x, area, geo.xMax));
+  };
+
+  const hoverX =
+    hover !== null ? (geo.lines[0]?.points[hover]?.x ?? null) : null;
+  // ツールチップの左位置（コンテナ幅に対する %）。viewBox 幅に対する比で出す
+  const hoverLeftPct = hoverX !== null ? (hoverX / geo.width) * 100 : 0;
+  const hoverSnap = hover !== null ? series[hover] : undefined;
 
   return (
     <div className="flex flex-col gap-2">
-      <svg
-        viewBox={`0 0 ${geo.width} ${geo.height}`}
-        className="h-auto w-full"
-        role="img"
-        aria-label="シミュレーション結果の時系列グラフ"
-      >
-        {/* y 軸の目盛り線とラベル */}
-        {geo.yTicks.map((tick) => (
-          <g key={`y-${tick.value}`}>
+      <div className="relative">
+        <svg
+          viewBox={`0 0 ${geo.width} ${geo.height}`}
+          className="h-auto w-full"
+          role="img"
+          aria-label="シミュレーション結果の時系列グラフ"
+          onMouseMove={handleMove}
+          onMouseLeave={() => setHover(null)}
+        >
+          {/* y 軸の目盛り線とラベル */}
+          {geo.yTicks.map((tick) => (
+            <g key={`y-${tick.value}`}>
+              <line
+                x1={area.left}
+                y1={tick.y}
+                x2={area.right}
+                y2={tick.y}
+                stroke="var(--grid-line)"
+                strokeWidth={1}
+              />
+              <text
+                x={area.left - 6}
+                y={tick.y}
+                textAnchor="end"
+                dominantBaseline="middle"
+                className="fill-muted-foreground text-[9px]"
+              >
+                {formatTick(tick.value)}
+              </text>
+            </g>
+          ))}
+
+          {/* x 軸の基線と両端の t ラベル */}
+          <line
+            x1={area.left}
+            y1={area.bottom}
+            x2={area.right}
+            y2={area.bottom}
+            stroke="var(--grid-line)"
+            strokeWidth={1}
+          />
+          <text
+            x={area.left}
+            y={area.bottom + 14}
+            textAnchor="start"
+            className="fill-muted-foreground text-[9px]"
+          >
+            t=0
+          </text>
+          <text
+            x={area.right}
+            y={area.bottom + 14}
+            textAnchor="end"
+            className="fill-muted-foreground text-[9px]"
+          >
+            t={geo.xMax}
+          </text>
+
+          {/* ホバー位置の縦ガイド線 */}
+          {hoverX !== null && (
             <line
-              x1={area.left}
-              y1={tick.y}
-              x2={area.right}
-              y2={tick.y}
+              x1={hoverX}
+              y1={area.top}
+              x2={hoverX}
+              y2={area.bottom}
               stroke="var(--grid-line)"
               strokeWidth={1}
+              strokeDasharray="3 3"
             />
-            <text
-              x={area.left - 6}
-              y={tick.y}
-              textAnchor="end"
-              dominantBaseline="middle"
-              className="fill-muted-foreground text-[9px]"
-            >
-              {formatTick(tick.value)}
-            </text>
-          </g>
-        ))}
+          )}
 
-        {/* x 軸の基線と両端の t ラベル */}
-        <line
-          x1={area.left}
-          y1={area.bottom}
-          x2={area.right}
-          y2={area.bottom}
-          stroke="var(--grid-line)"
-          strokeWidth={1}
-        />
-        <text
-          x={area.left}
-          y={area.bottom + 14}
-          textAnchor="start"
-          className="fill-muted-foreground text-[9px]"
-        >
-          t=0
-        </text>
-        <text
-          x={area.right}
-          y={area.bottom + 14}
-          textAnchor="end"
-          className="fill-muted-foreground text-[9px]"
-        >
-          t={geo.xMax}
-        </text>
+          {/* 各系列の折れ線（1 点のみのときは点で表す） */}
+          {geo.lines.map((line) =>
+            line.points.length === 1 ? (
+              <circle
+                key={line.name}
+                cx={line.points[0].x}
+                cy={line.points[0].y}
+                r={2.5}
+                fill={line.color}
+              />
+            ) : (
+              <polyline
+                key={line.name}
+                points={line.points.map((p) => `${p.x},${p.y}`).join(" ")}
+                fill="none"
+                stroke={line.color}
+                strokeWidth={1.75}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            ),
+          )}
 
-        {/* 各系列の折れ線（1 点のみのときは点で表す） */}
-        {geo.lines.map((line) =>
-          line.points.length === 1 ? (
-            <circle
-              key={line.name}
-              cx={line.points[0].x}
-              cy={line.points[0].y}
-              r={2.5}
-              fill={line.color}
-            />
-          ) : (
-            <polyline
-              key={line.name}
-              points={line.points.map((p) => `${p.x},${p.y}`).join(" ")}
-              fill="none"
-              stroke={line.color}
-              strokeWidth={1.75}
-              strokeLinejoin="round"
-              strokeLinecap="round"
-            />
-          ),
+          {/* ホバー位置の各系列の点 */}
+          {hover !== null &&
+            geo.lines.map((line) => {
+              const p = line.points[hover];
+              if (!p) return null;
+              return (
+                <circle
+                  key={`h-${line.name}`}
+                  cx={p.x}
+                  cy={p.y}
+                  r={3}
+                  fill={line.color}
+                  stroke="var(--card)"
+                  strokeWidth={1}
+                />
+              );
+            })}
+        </svg>
+
+        {/* ホバー時のツールチップ（HTML） */}
+        {hover !== null && hoverSnap && geo.lines.length > 0 && (
+          <div
+            className="pointer-events-none absolute top-0 z-10 -translate-x-1/2 rounded-md border bg-card/95 px-2 py-1 text-[11px] shadow-md backdrop-blur-sm"
+            style={{
+              left: `${Math.min(85, Math.max(15, hoverLeftPct))}%`,
+            }}
+          >
+            <div className="mb-0.5 text-muted-foreground">t={hover}</div>
+            <ul className="space-y-0.5">
+              {geo.lines.map((line) => (
+                <li
+                  key={`tt-${line.name}`}
+                  className="flex items-center gap-1.5"
+                >
+                  <span
+                    aria-hidden
+                    className="inline-block size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: line.color }}
+                  />
+                  <span className="text-muted-foreground">{line.name}</span>
+                  <span className="ml-auto font-medium tabular-nums">
+                    {formatTick(hoverSnap[line.name])}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
-      </svg>
+      </div>
 
       {/* 凡例（折り返し可能な HTML） */}
       <ul className="flex flex-wrap gap-x-3 gap-y-1">

--- a/src/app/(main)/projects/[projectId]/_components/sim-inputs.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-inputs.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
-import { canSimulate, toSimEdges, toSimNodes } from "./sim-inputs";
+import {
+  canSimulate,
+  toSimEdges,
+  toSimNodes,
+  visibleSeriesNames,
+} from "./sim-inputs";
 
 /** テスト用に DiagramNode を最小プロパティから組む */
 function node(
@@ -106,5 +111,34 @@ describe("canSimulate", () => {
     expect(
       canSimulate(toSimNodes([node({ id: "1", name: "x", kind: null })])),
     ).toBe(false);
+  });
+});
+
+describe("visibleSeriesNames", () => {
+  const simNodes = toSimNodes([
+    node({ id: "1", name: "残高", kind: "stock", initialValue: 100 }),
+    node({ id: "2", name: "利息", kind: "flow", expression: "残高 * 0.1" }),
+    node({ id: "3", name: "利率", kind: "auxiliary", expression: "0.1" }),
+    node({ id: "4", name: "元本", kind: "constant", value: 100 }),
+  ]);
+
+  it("all は全系列を元の順序で返す", () => {
+    expect(visibleSeriesNames(simNodes, "all")).toEqual([
+      "残高",
+      "利息",
+      "利率",
+      "元本",
+    ]);
+  });
+
+  it("stock は kind=stock のみ返す", () => {
+    expect(visibleSeriesNames(simNodes, "stock")).toEqual(["残高"]);
+  });
+
+  it("stock が無ければ空配列", () => {
+    const noStock = toSimNodes([
+      node({ id: "1", name: "率", kind: "flow", expression: "1" }),
+    ]);
+    expect(visibleSeriesNames(noStock, "stock")).toEqual([]);
   });
 });

--- a/src/app/(main)/projects/[projectId]/_components/sim-inputs.ts
+++ b/src/app/(main)/projects/[projectId]/_components/sim-inputs.ts
@@ -43,3 +43,18 @@ export function toSimEdges(edges: DiagramEdge[]): SimEdge[] {
 export function canSimulate(simNodes: SimNode[]): boolean {
   return simNodes.some((node) => node.kind === "stock");
 }
+
+export type SeriesMode = "all" | "stock";
+
+/**
+ * グラフに描く系列（ノード名）を表示モードで絞る。色は名前順 index で決まるため
+ * 元の並び順を保つ。"stock" は kind==="stock" のみ、"all" は全 SimNode。
+ */
+export function visibleSeriesNames(
+  simNodes: SimNode[],
+  mode: SeriesMode,
+): string[] {
+  return simNodes
+    .filter((node) => mode === "all" || node.kind === "stock")
+    .map((node) => node.name);
+}

--- a/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
@@ -1,15 +1,27 @@
 "use client";
 
-import { CaretDownIcon, ChartLineIcon, PlayIcon } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import {
+  ArrowsOutIcon,
+  CaretDownIcon,
+  ChartLineIcon,
+  PlayIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { type SimResult, simulate } from "@/lib/diagram/simulate";
 import type { Diagram } from "@/lib/queries/diagrams";
 import { cn } from "@/lib/utils";
-import { SimChart } from "./sim-chart";
-import { canSimulate, toSimEdges, toSimNodes } from "./sim-inputs";
+import { LARGE_DIMS, SimChart } from "./sim-chart";
+import {
+  canSimulate,
+  type SeriesMode,
+  toSimEdges,
+  toSimNodes,
+  visibleSeriesNames,
+} from "./sim-inputs";
 
 type SimulationPanelProps = {
   diagram: Diagram;
@@ -25,16 +37,38 @@ export function SimulationPanel({ diagram }: SimulationPanelProps) {
   const [dt, setDt] = useState("1");
   const [steps, setSteps] = useState("20");
   const [result, setResult] = useState<SimResult | null>(null);
+  const [mode, setMode] = useState<SeriesMode>("all");
+  const [expanded, setExpanded] = useState(false);
 
-  const { simNodes, simEdges, names, runnable } = useMemo(() => {
+  const { simNodes, simEdges, runnable } = useMemo(() => {
     const simNodes = toSimNodes(diagram.nodes);
     return {
       simNodes,
       simEdges: toSimEdges(diagram.edges),
-      names: simNodes.map((n) => n.name),
       runnable: canSimulate(simNodes),
     };
   }, [diagram]);
+
+  // 表示モードに応じて描く系列を絞る（all=全 kind / stock=ストックのみ）
+  const names = useMemo(
+    () => visibleSeriesNames(simNodes, mode),
+    [simNodes, mode],
+  );
+
+  // 拡大オーバーレイ表示中は背景スクロールを止め、Esc で閉じられるようにする
+  useEffect(() => {
+    if (!expanded) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      document.body.style.overflow = prev;
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [expanded]);
 
   const run = () => {
     // 数値変換は simulate 側の config 検証に委ねる（空欄→0, 不正→NaN はそこで
@@ -105,6 +139,35 @@ export function SimulationPanel({ diagram }: SimulationPanelProps) {
             </Button>
           </div>
 
+          {runnable && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">表示</span>
+              <div className="flex gap-1">
+                <ModeButton
+                  active={mode === "stock"}
+                  onClick={() => setMode("stock")}
+                >
+                  ストックのみ
+                </ModeButton>
+                <ModeButton
+                  active={mode === "all"}
+                  onClick={() => setMode("all")}
+                >
+                  すべて
+                </ModeButton>
+              </div>
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                disabled={!result?.ok}
+                aria-label="グラフを拡大"
+                className="ml-auto rounded-md border p-1.5 text-muted-foreground transition-colors hover:bg-accent disabled:opacity-40"
+              >
+                <ArrowsOutIcon className="size-3.5" />
+              </button>
+            </div>
+          )}
+
           <div className="min-h-24">
             {!runnable ? (
               <p className="text-muted-foreground text-sm leading-relaxed">
@@ -116,7 +179,13 @@ export function SimulationPanel({ diagram }: SimulationPanelProps) {
                 を決めて「実行」すると、各変数の時間変化が描かれます。
               </p>
             ) : result.ok ? (
-              <SimChart series={result.series} names={names} />
+              names.length > 0 ? (
+                <SimChart series={result.series} names={names} />
+              ) : (
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  表示する系列がありません（ストックがありません）。
+                </p>
+              )
             ) : (
               <p className="text-(--vermilion) text-sm leading-relaxed">
                 {result.error.message}
@@ -125,6 +194,67 @@ export function SimulationPanel({ diagram }: SimulationPanelProps) {
           </div>
         </div>
       )}
+
+      {expanded && result?.ok && (
+        // biome-ignore lint/a11y/noStaticElementInteractions: 背景クリックで閉じる軽量オーバーレイ。閉じる操作は ✕ ボタンと Esc でも可能
+        // biome-ignore lint/a11y/useKeyWithClickEvents: Esc と ✕ ボタンで閉じられる。背景クリックは補助的な手段
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-6 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setExpanded(false);
+          }}
+        >
+          <div className="relative max-h-[90vh] w-full max-w-3xl overflow-auto rounded-lg border bg-card p-6 shadow-lg">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="font-serif text-sm">シミュレーション結果</h2>
+              <button
+                type="button"
+                onClick={() => setExpanded(false)}
+                aria-label="閉じる"
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent"
+              >
+                <XIcon className="size-4" />
+              </button>
+            </div>
+            {names.length > 0 ? (
+              <SimChart
+                series={result.series}
+                names={names}
+                dims={LARGE_DIMS}
+              />
+            ) : (
+              <p className="text-muted-foreground text-sm">
+                表示する系列がありません。
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
+  );
+}
+
+function ModeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-md border px-2 py-1 font-serif text-xs transition-colors",
+        active
+          ? "border-ink bg-ink/10 text-ink"
+          : "text-muted-foreground hover:bg-accent",
+      )}
+    >
+      {children}
+    </button>
   );
 }

--- a/src/app/(main)/projects/[projectId]/_components/workspace.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/workspace.tsx
@@ -3,7 +3,7 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { InterviewNotes } from "@/lib/interview/notes";
 import type { InterviewPhase } from "@/lib/interview/phase";
@@ -52,10 +52,26 @@ export function Workspace({
     },
   });
 
+  // 対話エリアの幅（%）。md+ の横並びレイアウト時のみ反映。ドラッグで 25〜60% に可変
+  const containerRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const [leftPct, setLeftPct] = useState(40);
+
+  const onHandleMove = (e: React.PointerEvent) => {
+    if (!draggingRef.current || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const pct = ((e.clientX - rect.left) / rect.width) * 100;
+    setLeftPct(Math.max(25, Math.min(60, pct)));
+  };
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+    <div
+      ref={containerRef}
+      className="flex min-h-0 flex-1 flex-col md:flex-row"
+    >
       <section
-        className="flex min-h-0 flex-1 flex-col border-b md:max-w-[40%] md:border-r md:border-b-0"
+        className="flex min-h-0 w-full flex-col border-b md:shrink-0 md:border-b-0 md:[width:var(--left-w)]"
+        style={{ ["--left-w" as string]: `${leftPct}%` } as React.CSSProperties}
         aria-label="対話"
       >
         <NotesPanel notes={notes} phase={phase} />
@@ -66,6 +82,26 @@ export function Workspace({
           stop={stop}
         />
       </section>
+      {/* 幅可変ハンドル（md+ のみ）。pointer capture で確実にドラッグを拾う。
+          button にしてキーボード（左右キー）でも調整可能にする */}
+      <button
+        type="button"
+        aria-label="対話エリアの幅を調整"
+        className="hidden w-1.5 shrink-0 cursor-col-resize touch-none select-none bg-border transition-colors hover:bg-ring md:block"
+        onPointerDown={(e) => {
+          draggingRef.current = true;
+          e.currentTarget.setPointerCapture(e.pointerId);
+        }}
+        onPointerMove={onHandleMove}
+        onPointerUp={(e) => {
+          draggingRef.current = false;
+          e.currentTarget.releasePointerCapture(e.pointerId);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowLeft") setLeftPct((p) => Math.max(25, p - 2));
+          if (e.key === "ArrowRight") setLeftPct((p) => Math.min(60, p + 2));
+        }}
+      />
       <section className="relative min-h-0 flex-1" aria-label="因果ループ図">
         <DiagramCanvas projectId={project.id} diagram={diagram} />
       </section>


### PR DESCRIPTION
## 概要

スライス C で入れたシミュレーショングラフの使い勝手を 4 点改善。計算（simulate）やデータには触らず、表示/レイアウトのみ。

**スタック PR**: base は `feat/m3-ai-sfd`（[#5](https://github.com/mittsmasa/interlink/pull/5)）。下流がマージされると自動で main へ張り替わる。

## 変更点

1. **グラフ拡大**: パネルの拡大ボタンで大きいグラフのオーバーレイ（dialog ライブラリを足さず自前。Esc / ✕ / 背景クリックで閉じ、表示中は背景スクロール抑止）。`SimChart` に `dims` を任意 prop 化し、小（パネル内）と大（`LARGE_DIMS`）で同一コンポーネントを共用
2. **対話エリアの幅可変**: `workspace` の左右間にドラッグハンドル（25〜60% クランプ、md+ のみ）。pointer capture でドラッグを確実に拾い、`<button>` 化して左右キーでも調整可
3. **ホバー値表示**: `SimChart` を `"use client"` 化。`getScreenCTM().inverse()` で SVG 座標へ換算し最近傍 t を求め、縦ガイド線 + 各点ハイライト + ツールチップ（各系列名と値）を表示
4. **系列切替**: 「ストックのみ / すべて」トグル（既定すべて）。常に平らな定数などを隠せる

純粋ロジック（`nearestIndexForX` / `visibleSeriesNames`）はヘルパに切り出して単体テスト。

## 検証

- `pnpm check` exit 0 / `pnpm test` 15 files / 133 tests PASS（D の 129 + 新規 4）
- ui-verify（実ブラウザ）: 残高モデルで 4 機能を確認 — 系列トグルで残高のみに絞れる / 拡大オーバーレイ開閉 / ホバーで t=11 の各値表示 / ハンドルのドラッグで対話幅 512→720px に変化

## 補足（dt / steps の使い分け、関連 Q&A）

- steps = 横軸の長さ（点の数）。長期を見たいなら steps を増やす
- dt = 時間刻み。1 ステップの変化量 = フロー × dt。大きすぎるとオイラー法で振動・発散しやすい。線が暴れるなら dt を下げて steps を増やす（総期間 ≒ dt × steps）

🤖 Generated with [Claude Code](https://claude.com/claude-code)