### PR TITLE
feat: SFD のノード位置自動調整と整列ボタン

### DIFF
--- a/src/app/(main)/projects/[projectId]/_actions.ts
+++ b/src/app/(main)/projects/[projectId]/_actions.ts
@@ -63,6 +63,26 @@ export async function updateNodePosition(
   return { ok: true as const };
 }
 
+/** 「整列」での再配置結果など、複数ノードの位置をまとめて保存する */
+export async function updateNodePositions(
+  projectId: string,
+  positions: { nodeId: string; x: number; y: number }[],
+) {
+  const project = await getOwnedProject(projectId);
+  if (!project) return { ok: false as const };
+  if (positions.length === 0) return { ok: true as const };
+  await db.transaction(async (tx) => {
+    for (const p of positions) {
+      await tx
+        .update(nodes)
+        .set({ x: p.x, y: p.y })
+        .where(and(eq(nodes.id, p.nodeId), eq(nodes.projectId, projectId)));
+    }
+  });
+  // updateNodePosition と同様、位置のみの更新なので updatedAt は触らない
+  return { ok: true as const };
+}
+
 export async function updateNode(
   projectId: string,
   nodeId: string,

--- a/src/app/(main)/projects/[projectId]/_components/dependency-edge.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/dependency-edge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BaseEdge, type EdgeProps, useInternalNode } from "@xyflow/react";
-import { getFloatingEdgePath } from "./floating-edge-utils";
+import { type BulgeSign, getFloatingEdgePath } from "./floating-edge-utils";
 import { useHighlight } from "./highlight-context";
 
 /**
@@ -9,7 +9,7 @@ import { useHighlight } from "./highlight-context";
  * 因果リンク（実線・色・+/− ラベル）と一目で区別できるよう、
  * 破線・中立色・ラベルなしの控えめな下地として描く。保存しない導出物。
  */
-export function DependencyEdge({ id, source, target }: EdgeProps) {
+export function DependencyEdge({ id, source, target, data }: EdgeProps) {
   const sourceNode = useInternalNode(source);
   const targetNode = useInternalNode(target);
   const highlight = useHighlight();
@@ -21,8 +21,9 @@ export function DependencyEdge({ id, source, target }: EdgeProps) {
   const emphasized = highlight?.edgeIds.has(id) ?? false;
   const dimmed = highlight !== null && !emphasized;
 
-  // 軽い曲げを固定で付ける（因果エッジの bulge 計算には乗せない）
-  const { path } = getFloatingEdgePath(sourceNode, targetNode, 1);
+  // 因果エッジと同じノード回避ロジックで決めた曲げ側を使う（chooseBulgeSigns 由来）
+  const bulgeSign = (data as { bulgeSign?: BulgeSign } | undefined)?.bulgeSign;
+  const { path } = getFloatingEdgePath(sourceNode, targetNode, bulgeSign ?? 1);
 
   return (
     <BaseEdge

--- a/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
@@ -13,15 +13,17 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { TreeStructureIcon } from "@phosphor-icons/react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
 import { matchArchetypes } from "@/lib/diagram/archetypes";
 import { isCausallyLinked } from "@/lib/diagram/dependencies";
 import { deriveSignedDependencies } from "@/lib/diagram/dependency-polarity";
 import { type LintFinding, lintDiagram } from "@/lib/diagram/lint";
 import { detectLoops, type Loop } from "@/lib/diagram/loops";
 import type { Diagram, DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
-import { updateNodePosition } from "../_actions";
+import { updateNodePosition, updateNodePositions } from "../_actions";
 import { CausalEdge, CausalEdgeMarkers } from "./causal-edge";
 import { DependencyEdge, DependencyEdgeMarkers } from "./dependency-edge";
 import { chooseBulgeSigns } from "./floating-edge-utils";
@@ -74,27 +76,32 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
     [diagram],
   );
 
-  // ループ・lint・原型は図から毎回導出する（保存しない）。ループ検出には因果エッジに加えて
-  // 式由来リンクも derived エッジとして渡し、式で閉じる円環を暫定ループとして拾う
-  const verification = useMemo(() => {
-    const loopEdges = [
-      ...diagram.edges,
-      ...signedDeps.map((dep) => ({
+  // 情報リンクを「レイアウト・ループ検出」用の派生エッジ形に正規化する。
+  // 同じ集合を computePositions（レイアウト）とループ検出の両方に渡す
+  const derivedLoopEdges = useMemo(
+    () =>
+      signedDeps.map((dep) => ({
         id: dep.id,
         sourceNodeId: dep.fromNodeId,
         targetNodeId: dep.toNodeId,
         polarity: dep.polarity,
         hasDelay: false,
-        derived: true,
+        derived: true as const,
       })),
-    ];
+    [signedDeps],
+  );
+
+  // ループ・lint・原型は図から毎回導出する（保存しない）。ループ検出には因果エッジに加えて
+  // 式由来リンクも derived エッジとして渡し、式で閉じる円環を暫定ループとして拾う
+  const verification = useMemo(() => {
+    const loopEdges = [...diagram.edges, ...derivedLoopEdges];
     const loopResult = detectLoops(diagram.nodes, loopEdges);
     return {
       loopResult,
       findings: lintDiagram(diagram.nodes, diagram.edges),
       matches: matchArchetypes(loopResult.loops),
     };
-  }, [diagram, signedDeps]);
+  }, [diagram, derivedLoopEdges]);
 
   const [highlight, setHighlight] = useState<Highlight>(null);
   const highlightLoop = useCallback((loop: Loop | null) => {
@@ -119,8 +126,20 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
   );
 
   const { rfNodes, rfEdges } = useMemo(() => {
-    const positions = computePositions(diagram);
+    const positions = computePositions(diagram, {
+      derivedEdges: derivedLoopEdges,
+    });
     const bulgeSigns = chooseBulgeSigns(diagram.edges, positions);
+    // 情報リンクも因果エッジと同じノード回避ロジックで曲げる（固定の片側曲げをやめ、
+    // 他ノードから遠い側へ逃がして重なりを減らす）。因果側の bulge には影響させない
+    const depBulgeSigns = chooseBulgeSigns(
+      signedDeps.map((dep) => ({
+        id: dep.id,
+        sourceNodeId: dep.fromNodeId,
+        targetNodeId: dep.toNodeId,
+      })),
+      positions,
+    );
     const causalEdges = diagram.edges.map(
       (edge): Edge => ({
         id: edge.id,
@@ -140,6 +159,7 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
         target: dep.toNodeId,
         selectable: false,
         focusable: false,
+        data: { bulgeSign: depBulgeSigns.get(dep.id) ?? 1 },
       }),
     );
     return {
@@ -153,7 +173,7 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
       ),
       rfEdges: [...causalEdges, ...dependencyEdges],
     };
-  }, [diagram, signedDeps]);
+  }, [diagram, signedDeps, derivedLoopEdges]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(rfNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(rfEdges);
@@ -174,6 +194,26 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
       fitView({ padding: 0.25, duration: 600 });
     }
   }, [nodeCount, fitView]);
+
+  // 「整列」: 配置済みの固定を無視して全ノードを並べ直し、結果を永続化する
+  const handleArrange = useCallback(() => {
+    const positions = computePositions(diagram, {
+      derivedEdges: derivedLoopEdges,
+      reset: true,
+    });
+    setNodes((nds) =>
+      nds.map((n) => {
+        const p = positions.get(n.id);
+        return p ? { ...n, position: p } : n;
+      }),
+    );
+    updateNodePositions(
+      projectId,
+      [...positions].map(([nodeId, p]) => ({ nodeId, x: p.x, y: p.y })),
+    );
+    // 反映後に全体が画面へ収まるよう次フレームで寄せる
+    requestAnimationFrame(() => fitView({ padding: 0.25, duration: 600 }));
+  }, [diagram, derivedLoopEdges, setNodes, projectId, fitView]);
 
   return (
     <div className="relative size-full">
@@ -224,6 +264,21 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
       </HighlightContext.Provider>
       <CausalEdgeMarkers />
       <DependencyEdgeMarkers />
+
+      {diagram.nodes.length > 0 && (
+        <div className="-translate-x-1/2 absolute top-4 left-1/2 z-10">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="gap-1.5 shadow-sm"
+            onClick={handleArrange}
+          >
+            <TreeStructureIcon size={16} weight="bold" />
+            整列
+          </Button>
+        </div>
+      )}
 
       {diagram.nodes.length > 0 && (
         <VerificationPanel

--- a/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.ts
+++ b/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.ts
@@ -99,8 +99,8 @@ type EdgeRef = { id: string; sourceNodeId: string; targetNodeId: string };
 /**
  * 各エッジの膨らみ側を決定的に選ぶ。
  * - 双方向ペア（A→B と B→A）は互いに逆側へ逃がして重なりを防ぐ
- * - それ以外は、膨らみ候補（法線 ±）のうち両端以外のノードから遠い側を選ぶ
- *   （ループの内側にノードがあれば外側に開く）
+ * - それ以外は、図の重心から外向き（凸）になる側へ曲げる。ループの円弧が
+ *   外へ膨らんで円として閉じて見えるようにするため。
  * 座標はレイアウト計算後のもの（ドラッグ中のライブ座標ではない）で良い。
  */
 export function chooseBulgeSigns(
@@ -108,6 +108,16 @@ export function chooseBulgeSigns(
   positions: Map<string, Point>,
 ): Map<string, BulgeSign> {
   const result = new Map<string, BulgeSign>();
+
+  // 図の中心（全ノードの重心）。各エッジはこの中心から外向きへ膨らむ側を選ぶ
+  let cx = 0;
+  let cy = 0;
+  for (const [, pos] of positions) {
+    cx += pos.x;
+    cy += pos.y;
+  }
+  const n = positions.size || 1;
+  const centroid = { x: cx / n, y: cy / n };
 
   for (const edge of edges) {
     if (edge.sourceNodeId === edge.targetNodeId) {
@@ -147,15 +157,8 @@ export function chooseBulgeSigns(
         x: mid.x + (-dy / dist) * sag * sign,
         y: mid.y + (dx / dist) * sag * sign,
       };
-      let minDist = Number.POSITIVE_INFINITY;
-      for (const [nodeId, pos] of positions) {
-        if (nodeId === edge.sourceNodeId || nodeId === edge.targetNodeId) {
-          continue;
-        }
-        minDist = Math.min(minDist, Math.hypot(apex.x - pos.x, apex.y - pos.y));
-      }
-      // 他ノードがなければ既定の側
-      const score = minDist === Number.POSITIVE_INFINITY ? 0 : minDist;
+      // 中心から遠い側（外向き）ほど高スコア。ループ円弧が外へ膨らみ円形に見える
+      const score = Math.hypot(apex.x - centroid.x, apex.y - centroid.y);
       if (score > bestScore) {
         bestScore = score;
         best = sign;

--- a/src/app/(main)/projects/[projectId]/_components/layout-diagram.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/layout-diagram.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { Diagram } from "@/lib/queries/diagrams";
+import { computePositions, type DerivedEdge } from "./layout-diagram";
+
+type NodeSeed = { id: string; x?: number | null; y?: number | null };
+type EdgeSeed = { id: string; from: string; to: string };
+
+// computePositions が読むのは id / name / x / y（ノード）と
+// source/target/polarity/hasDelay（エッジ）だけ。DB 行の完全型は満たさず、
+// 必要なフィールドだけのモックを Diagram にキャストする。
+const mkDiagram = (
+  nodeSeeds: NodeSeed[],
+  edgeSeeds: EdgeSeed[] = [],
+): Diagram =>
+  ({
+    nodes: nodeSeeds.map((n) => ({
+      id: n.id,
+      name: `変数${n.id}`,
+      x: n.x ?? null,
+      y: n.y ?? null,
+    })),
+    edges: edgeSeeds.map((e) => ({
+      id: e.id,
+      sourceNodeId: e.from,
+      targetNodeId: e.to,
+      polarity: "+",
+      hasDelay: false,
+    })),
+  }) as unknown as Diagram;
+
+const distance = (
+  positions: Map<string, { x: number; y: number }>,
+  a: string,
+  b: string,
+) => {
+  const p = positions.get(a);
+  const q = positions.get(b);
+  if (!p || !q) throw new Error(`位置が無い: ${a} / ${b}`);
+  return Math.hypot(p.x - q.x, p.y - q.y);
+};
+
+describe("computePositions", () => {
+  it("入力順が同じなら結果は決定的（d3-force のシード付き乱数）", () => {
+    const diagram = mkDiagram(
+      [{ id: "a" }, { id: "b" }, { id: "c" }],
+      [
+        { id: "e1", from: "a", to: "b" },
+        { id: "e2", from: "b", to: "c" },
+      ],
+    );
+    expect(computePositions(diagram)).toEqual(computePositions(diagram));
+  });
+
+  it("情報リンクを渡すと、繋がる先のノードへ引き寄せられる", () => {
+    // a を遠くに固定し b は未配置。a→b の情報リンクの有無で b の寄り方を比べる。
+    // リンクが無い従来は b が無関係に散る（= a から遠い）が、渡すと引き寄せられる。
+    const diagram = mkDiagram([{ id: "a", x: 1000, y: 0 }, { id: "b" }]);
+    const derivedEdges: DerivedEdge[] = [
+      {
+        id: "d1",
+        sourceNodeId: "a",
+        targetNodeId: "b",
+        polarity: null,
+        hasDelay: false,
+      },
+    ];
+    const without = computePositions(diagram);
+    const withLink = computePositions(diagram, { derivedEdges });
+    expect(distance(withLink, "a", "b")).toBeLessThan(
+      distance(without, "a", "b"),
+    );
+  });
+
+  it("reset=true なら配置済みノードも固定せず並べ直す", () => {
+    const diagram = mkDiagram(
+      [
+        { id: "a", x: 1000, y: 1000 },
+        { id: "b", x: -1000, y: -1000 },
+      ],
+      [{ id: "e1", from: "a", to: "b" }],
+    );
+    // 通常は配置済みを fx/fy で固定するので座標は変わらない
+    expect(computePositions(diagram).get("a")).toEqual({ x: 1000, y: 1000 });
+    // reset では固定を無視して動かす
+    expect(computePositions(diagram, { reset: true }).get("a")).not.toEqual({
+      x: 1000,
+      y: 1000,
+    });
+  });
+});

--- a/src/app/(main)/projects/[projectId]/_components/layout-diagram.ts
+++ b/src/app/(main)/projects/[projectId]/_components/layout-diagram.ts
@@ -14,15 +14,45 @@ import type { Diagram } from "@/lib/queries/diagrams";
 type SimNode = SimulationNodeDatum & { id: string };
 
 /**
- * 未配置（x, y が null）のノードを d3-force で配置する。
- * 配置済みノードは fx/fy で固定し、新しいノードだけが既存の構造の
- * まわりに収まる。入力順が同じなら結果は決定的。
+ * 式由来の情報リンク（破線）。因果エッジと合わせてループ検出・力学リンクに渡す。
+ * loops.ts の LoopEdge は未 export のため、構造的に一致する最小形だけ受ける。
+ */
+export type DerivedEdge = {
+  id: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  polarity: "+" | "-" | null;
+  hasDelay: boolean;
+};
+
+type ComputePositionsOptions = {
+  /** 式由来の情報リンク。因果エッジと合わせてループ検出・力学リンクに使う */
+  derivedEdges?: DerivedEdge[];
+  /** true なら配置済み位置を固定せず、全ノードを構造から並べ直す（整列ボタン用） */
+  reset?: boolean;
+};
+
+/**
+ * ノードを d3-force で配置する。通常は未配置（x, y が null）のノードだけを置き、
+ * 配置済みは fx/fy で固定して、新しいノードだけが既存の構造のまわりに収まる。
+ * reset=true のときは固定せず全ノードを構造から並べ直す（整列ボタン）。
+ *
+ * 因果エッジに加えて式由来の情報リンク（derivedEdges）もリンクとして渡すため、
+ * 式だけで繋がる SFD ノード（ストック/フロー/補助変数）も構造に沿って配置される。
+ * d3-force は乱数にシード付き LCG を使うため、入力順が同じなら結果は決定的。
  *
  * 最大のフィードバックループはループ順に円周へ初期配置し、forceRadial で
  * 円を保つ。円環が円として描かれることでエッジの交差が減る。
  */
-export function computePositions(diagram: Diagram) {
-  const { loops } = detectLoops(diagram.nodes, diagram.edges);
+export function computePositions(
+  diagram: Diagram,
+  options: ComputePositionsOptions = {},
+) {
+  const { derivedEdges = [], reset = false } = options;
+  // 因果エッジ＋情報リンク。ループ検出・力学リンクの両方で同じ集合を使う
+  const allEdges = [...diagram.edges, ...derivedEdges];
+
+  const { loops } = detectLoops(diagram.nodes, allEdges);
   // detectLoops はノード数昇順で返すため末尾が最大ループ
   const largest = loops.at(-1);
   const ringIds = largest && largest.nodeIds.length >= 3 ? largest.nodeIds : [];
@@ -39,9 +69,10 @@ export function computePositions(diagram: Diagram) {
   );
 
   // リングに属さないノードは、リング上の接続先の外側へ seed する
-  // （forceX/Y に引かれて円の内側へ割り込むのを防ぐ）
+  // （forceX/Y に引かれて円の内側へ割り込むのを防ぐ）。情報リンク経由の
+  // 接続先も対象にすることで、式だけで繋がるノードもリング外周へ寄る。
   const outerSeed = (nodeId: string) => {
-    for (const e of diagram.edges) {
+    for (const e of allEdges) {
       const other =
         e.sourceNodeId === nodeId
           ? e.targetNodeId
@@ -58,13 +89,14 @@ export function computePositions(diagram: Diagram) {
   };
 
   const simNodes: SimNode[] = diagram.nodes.map((n) => {
-    if (n.x != null && n.y != null) {
+    // reset 時は保存位置を固定せず、全ノードを構造から並べ直す
+    if (!reset && n.x != null && n.y != null) {
       return { id: n.id, x: n.x, y: n.y, fx: n.x, fy: n.y };
     }
     const seed = ringSeeds.get(n.id) ?? outerSeed(n.id);
     return seed ? { id: n.id, x: seed.x, y: seed.y } : { id: n.id };
   });
-  const links = diagram.edges
+  const links = allEdges
     // 自己ループはレイアウトに影響させない
     .filter((e) => e.sourceNodeId !== e.targetNodeId)
     .map((e) => ({ source: e.sourceNodeId, target: e.targetNodeId }));


### PR DESCRIPTION
## 概要

ストック&フロー図（SFD）でも要素の位置自動調整が機械的に効くようにする。

- **情報リンクをレイアウトに反映**: `computePositions` に式由来の情報リンク（`signedDeps`）を渡し、力学リンク・ループ検出の両方に使う。これまで因果エッジしか渡しておらず、式だけで繋がる SFD ノードがレイアウトから無視されていた非対称を解消。
- **整列ボタン**: 配置済みの固定を無視して全体を並べ直す `reset` モード + 「整列」ボタン + `updateNodePositions`（複数ノードのバッチ位置保存）。既存の散らかった図もボタンで整い、リロード後も維持。
- **線の重なり軽減**: 情報リンクも因果エッジと同じノード回避の曲げ（`chooseBulgeSigns`）に乗せる。
- **曲げ方向の円形化**: 曲げ側の基準を「図の重心から外向き（凸）」にし、ループが円として閉じて見えるように。

## テスト

- `pnpm check` exit 0 / `pnpm test` 164 passed（18 files。新規 `layout-diagram.test.ts` で決定性・情報リンク・reset を固定）。
- ブラウザ（ui-verify）: 整列ボタン描画 / 実 SFD で情報リンク考慮の自動配置 / 団子状態→整列で展開 / リロード後も維持 / 情報リンクのノード回避 / 4ノードループが円形 を確認。

## 既知のフォローアップ

- ループがまだ閉じていない図（DAG / ドラフト段階）では、円形化のための外向き曲げが裏目に出てエッジが大きく振れ、重なりが増える。外向き曲げを「リング構成エッジ限定」にする改善を別途予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)