### PR TITLE
fix: リング非参加エッジの外向き曲げを無効化し DAG の弧の重なりを解消

### DIFF
--- a/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
@@ -29,7 +29,7 @@ import { DependencyEdge, DependencyEdgeMarkers } from "./dependency-edge";
 import { chooseBulgeSigns } from "./floating-edge-utils";
 import { type Highlight, HighlightContext } from "./highlight-context";
 import { InspectorPanel } from "./inspector-panel";
-import { computePositions } from "./layout-diagram";
+import { computePositions, selectRingNodeIds } from "./layout-diagram";
 import { LoopBadges } from "./loop-badges";
 import { SimulationPanel } from "./simulation-panel";
 import { VariableNode } from "./variable-node";
@@ -129,8 +129,13 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
     const positions = computePositions(diagram, {
       derivedEdges: derivedLoopEdges,
     });
-    const bulgeSigns = chooseBulgeSigns(diagram.edges, positions);
-    // 情報リンクも因果エッジと同じノード回避ロジックで曲げる（固定の片側曲げをやめ、
+    // computePositions と同一エッジ集合由来の loops から ring を導出（基準を揃える）。
+    // 両端とも ring 上のエッジだけ重心外向きに曲げ、それ以外はノード回避に任せる
+    const ringNodeIds = new Set(
+      selectRingNodeIds(verification.loopResult.loops),
+    );
+    const bulgeSigns = chooseBulgeSigns(diagram.edges, positions, ringNodeIds);
+    // 情報リンクも因果エッジと同じロジックで曲げる（固定の片側曲げをやめ、
     // 他ノードから遠い側へ逃がして重なりを減らす）。因果側の bulge には影響させない
     const depBulgeSigns = chooseBulgeSigns(
       signedDeps.map((dep) => ({
@@ -139,6 +144,7 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
         targetNodeId: dep.toNodeId,
       })),
       positions,
+      ringNodeIds,
     );
     const causalEdges = diagram.edges.map(
       (edge): Edge => ({
@@ -173,7 +179,7 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
       ),
       rfEdges: [...causalEdges, ...dependencyEdges],
     };
-  }, [diagram, signedDeps, derivedLoopEdges]);
+  }, [diagram, signedDeps, derivedLoopEdges, verification.loopResult.loops]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(rfNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(rfEdges);

--- a/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.test.ts
+++ b/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.test.ts
@@ -7,6 +7,18 @@ const positions = new Map([
   ["c", { x: 150, y: 200 }],
 ]);
 
+// 重心外向きとノード回避が背反する配置。a→b の弦に対し、避けるべき近接ノード c は
+// 上側（y<0）にあるが、重心は下方の d/e に引かれて y>0 になる。
+// → ノード回避は下側 sign=+1、重心外向きは（重心から遠い）上側 sign=-1 を選び、結果が割れる。
+const ringDisagreePositions = new Map([
+  ["a", { x: 0, y: 0 }],
+  ["b", { x: 300, y: 0 }],
+  ["c", { x: 150, y: -80 }],
+  ["d", { x: 100, y: 400 }],
+  ["e", { x: 200, y: 400 }],
+]);
+const abEdge = [{ id: "e1", sourceNodeId: "a", targetNodeId: "b" }];
+
 describe("chooseBulgeSigns", () => {
   it("双方向ペアは同符号（進行方向基準の法線が逆向きのため物理的に逆側へ分かれる）", () => {
     const signs = chooseBulgeSigns(
@@ -48,6 +60,29 @@ describe("chooseBulgeSigns", () => {
     const signs = chooseBulgeSigns(
       [{ id: "e1", sourceNodeId: "a", targetNodeId: "a" }],
       positions,
+    );
+    expect(signs.get("e1")).toBe(1);
+  });
+
+  it("ring 指定なしはノード回避（近接ノードを避ける下側 +1）", () => {
+    const signs = chooseBulgeSigns(abEdge, ringDisagreePositions);
+    expect(signs.get("e1")).toBe(1);
+  });
+
+  it("両端が ring 上なら重心外向き（ノード回避とは逆の上側 -1）", () => {
+    const signs = chooseBulgeSigns(
+      abEdge,
+      ringDisagreePositions,
+      new Set(["a", "b"]),
+    );
+    expect(signs.get("e1")).toBe(-1);
+  });
+
+  it("片端だけ ring 上ならノード回避のまま（+1）", () => {
+    const signs = chooseBulgeSigns(
+      abEdge,
+      ringDisagreePositions,
+      new Set(["a"]),
     );
     expect(signs.get("e1")).toBe(1);
   });

--- a/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.ts
+++ b/src/app/(main)/projects/[projectId]/_components/floating-edge-utils.ts
@@ -99,13 +99,17 @@ type EdgeRef = { id: string; sourceNodeId: string; targetNodeId: string };
 /**
  * 各エッジの膨らみ側を決定的に選ぶ。
  * - 双方向ペア（A→B と B→A）は互いに逆側へ逃がして重なりを防ぐ
- * - それ以外は、図の重心から外向き（凸）になる側へ曲げる。ループの円弧が
- *   外へ膨らんで円として閉じて見えるようにするため。
+ * - 両端ともに ring（最大ループ）上のエッジは、図の重心から外向き（凸）になる側へ曲げる。
+ *   ループの円弧が外へ膨らみ円として閉じて見えるようにするため。
+ * - それ以外のエッジは、膨らみ候補（法線 ±）のうち両端以外のノードから遠い側を選ぶ
+ *   （ノードの重なりを避ける）。ring が無い図で全エッジが重心外向きへ振れて交差するのを防ぐ。
  * 座標はレイアウト計算後のもの（ドラッグ中のライブ座標ではない）で良い。
+ * ringNodeIds を渡さない（または空集合の）場合は全エッジがノード回避になる。
  */
 export function chooseBulgeSigns(
   edges: EdgeRef[],
   positions: Map<string, Point>,
+  ringNodeIds?: ReadonlySet<string>,
 ): Map<string, BulgeSign> {
   const result = new Map<string, BulgeSign>();
 
@@ -150,6 +154,11 @@ export function chooseBulgeSigns(
     const sag = dist * SAGITTA_RATIO;
     const mid = { x: (s.x + t.x) / 2, y: (s.y + t.y) / 2 };
 
+    // 両端ともリング上なら重心外向き（円を閉じる）、それ以外はノード回避
+    const onRing =
+      (ringNodeIds?.has(edge.sourceNodeId) ?? false) &&
+      (ringNodeIds?.has(edge.targetNodeId) ?? false);
+
     let best: BulgeSign = 1;
     let bestScore = Number.NEGATIVE_INFINITY;
     for (const sign of [1, -1] as const) {
@@ -157,8 +166,25 @@ export function chooseBulgeSigns(
         x: mid.x + (-dy / dist) * sag * sign,
         y: mid.y + (dx / dist) * sag * sign,
       };
-      // 中心から遠い側（外向き）ほど高スコア。ループ円弧が外へ膨らみ円形に見える
-      const score = Math.hypot(apex.x - centroid.x, apex.y - centroid.y);
+      let score: number;
+      if (onRing) {
+        // 中心から遠い側（外向き）ほど高スコア。ループ円弧が外へ膨らみ円形に見える
+        score = Math.hypot(apex.x - centroid.x, apex.y - centroid.y);
+      } else {
+        // 両端以外のノードから最も遠い側を選び、ノードの重なりを避ける
+        let minDist = Number.POSITIVE_INFINITY;
+        for (const [nodeId, pos] of positions) {
+          if (nodeId === edge.sourceNodeId || nodeId === edge.targetNodeId) {
+            continue;
+          }
+          minDist = Math.min(
+            minDist,
+            Math.hypot(apex.x - pos.x, apex.y - pos.y),
+          );
+        }
+        // 他ノードがなければ既定の側（+1）
+        score = minDist === Number.POSITIVE_INFINITY ? 0 : minDist;
+      }
       if (score > bestScore) {
         bestScore = score;
         best = sign;

--- a/src/app/(main)/projects/[projectId]/_components/layout-diagram.ts
+++ b/src/app/(main)/projects/[projectId]/_components/layout-diagram.ts
@@ -14,6 +14,19 @@ import type { Diagram } from "@/lib/queries/diagrams";
 type SimNode = SimulationNodeDatum & { id: string };
 
 /**
+ * リング（円周配置）を構成するノード集合を選ぶ。最大フィードバックループが
+ * 3 ノード以上のときだけそのノード列を返す（2 ノード以下は円にしない）。
+ * detectLoops の loops はノード数昇順なので末尾が最大ループ。
+ * レイアウトの forceRadial と、エッジ曲げの外向き判定で同じ基準を使うため共有する。
+ */
+export function selectRingNodeIds(
+  loops: readonly { nodeIds: string[] }[],
+): string[] {
+  const largest = loops.at(-1);
+  return largest && largest.nodeIds.length >= 3 ? largest.nodeIds : [];
+}
+
+/**
  * 式由来の情報リンク（破線）。因果エッジと合わせてループ検出・力学リンクに渡す。
  * loops.ts の LoopEdge は未 export のため、構造的に一致する最小形だけ受ける。
  */
@@ -53,9 +66,7 @@ export function computePositions(
   const allEdges = [...diagram.edges, ...derivedEdges];
 
   const { loops } = detectLoops(diagram.nodes, allEdges);
-  // detectLoops はノード数昇順で返すため末尾が最大ループ
-  const largest = loops.at(-1);
-  const ringIds = largest && largest.nodeIds.length >= 3 ? largest.nodeIds : [];
+  const ringIds = selectRingNodeIds(loops);
   // 隣接ノードの間隔がおおむね link distance になる半径
   const ringRadius = Math.max(220, (ringIds.length * 280) / (2 * Math.PI));
   const ringSeeds = new Map(


### PR DESCRIPTION
## 概要

PR #9 で入った回帰を修正する。閉路の無い DAG（聞き取りドラフト段階）でエッジが重心から外向きに大きく振られ、ハブノード周りで弧が交差・重なる問題を解消する。閉路がある図の円形表示は維持する。

## 原因

`chooseBulgeSigns` の曲げ基準を PR #9 で「図の重心から外向き（凸）」に変更した。これはループを円形に閉じて見せる工夫だが、リング（円配置）が無い DAG では全エッジを中心から外へ曲げ、ハブ周りで大きな弧が交差していた。リング（`forceRadial` + 円周シード）は最大ループが 3 ノード以上のときだけ作られるため、それ以外の図では外向き曲げが意味を持たない。

## 変更

- `chooseBulgeSigns` に `ringNodeIds?: ReadonlySet<string>` を追加。両端ともに ring（最大ループ）上のエッジだけ重心外向きにし、それ以外は PR #9 以前のノード回避ヒューリスティック（弧頂点が両端以外のノードから遠い側）へ戻す。
- リング判定（最大ループが 3 ノード以上ならそのノード列）を `selectRingNodeIds` に抽出・export。`computePositions`（レイアウト）と曲げで同一基準を共有し、基準ずれ（drift）を防ぐ。`computePositions` の戻り値は変更しない。
- `diagram-canvas.tsx` は `verification.loopResult.loops`（`computePositions` と同一エッジ集合由来）から ring 集合を作り、causal・dependency 両方の呼び出しへ渡す。

## 確認

- `pnpm check` exit 0 / `pnpm test` 167 passed
- 追加テスト: 重心外向きとノード回避が背反する座標で、ring 指定/非指定/片端のみで bulge sign が分岐することを検証
- ブラウザ確認: DAG の before/after をスクショ比較し、位置同一・曲げのみ変化で外への振り回しが解消。リング図（5 ノード閉路）は円形を維持し回帰なし

## 備考

`diagram-canvas.tsx:197` の `suppressions/unused` 警告は本変更前から出ている既存のもので無関係。本 PR では触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
