### PR TITLE
chore: Vercel 本番関数を東京リージョン (hnd1) に固定

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm build",
+  "regions": ["hnd1"]
 }


### PR DESCRIPTION
## 背景
Turso DB は tokyo (aws-ap-northeast-1) にあるが、Vercel の関数は既定の `iad1` (US East) で実行されていた（`x-vercel-id: hnd1::iad1`）。DB クエリのたびに太平洋を往復しており、better-auth など DB を引く処理のレイテンシが大きい。

## 変更
- `vercel.json` に `regions: ["hnd1"]`（東京）を追加し、関数を DB と同一リージョンに固定

## 確認
- 再デプロイ後、`x-vercel-id` が `hnd1::iad1` → `hnd1::hnd1` に変化
- `vercel inspect` で全関数が `[hnd1]` 表記
- 本番 https://interlink-tau.vercel.app は READY（`get-session` 200 / DB 配線 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)