### PR TITLE
fix(workspace): モバイルで対話エリアが図を潰さないよう縦分割を固定

### DIFF
--- a/src/app/(main)/projects/[projectId]/_components/workspace.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/workspace.tsx
@@ -70,7 +70,7 @@ export function Workspace({
       className="flex min-h-0 flex-1 flex-col md:flex-row"
     >
       <section
-        className="flex min-h-0 w-full flex-col border-b md:shrink-0 md:border-b-0 md:[width:var(--left-w)]"
+        className="flex min-h-0 w-full flex-1 flex-col border-b md:flex-none md:shrink-0 md:border-b-0 md:[width:var(--left-w)]"
         style={{ ["--left-w" as string]: `${leftPct}%` } as React.CSSProperties}
         aria-label="対話"
       >


### PR DESCRIPTION
モバイル（flex-col）時、対話 section に高さ制約がなくメッセージ量に
応じて青天井に伸び、flex-1 の図 section を潰して図が見えなくなっていた。
section を flex-1 にして 50/50 に固定し、内部の overflow-y-auto で
スクロールさせる。デスクトップは md:flex-none で従来の横幅可変を維持。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011dm7onHaG4WWQ6nqxU2cYe