### PR TITLE
feat: 手動ノード・エッジ追加とパネル排他制御

### DIFF
--- a/src/app/(main)/projects/[projectId]/_actions.ts
+++ b/src/app/(main)/projects/[projectId]/_actions.ts
@@ -184,6 +184,61 @@ export async function updateEdge(
   return { ok: true as const };
 }
 
+export async function createNode(
+  projectId: string,
+  name: string,
+  x: number,
+  y: number,
+) {
+  const project = await getOwnedProject(projectId);
+  const trimmed = name.trim();
+  if (!project || !trimmed)
+    return { ok: false as const, error: "名前は必須です" };
+
+  const siblings = await db.query.nodes.findMany({
+    where: eq(nodes.projectId, projectId),
+    columns: { name: true },
+  });
+  if (siblings.some((s) => normalizeName(s.name) === normalizeName(trimmed))) {
+    return { ok: false as const, error: `変数「${trimmed}」は既にあります` };
+  }
+
+  await db.insert(nodes).values({ projectId, name: trimmed, x, y });
+  await touchProject(projectId);
+  return { ok: true as const };
+}
+
+export async function createEdge(
+  projectId: string,
+  sourceNodeId: string,
+  targetNodeId: string,
+  polarity: Polarity,
+) {
+  const project = await getOwnedProject(projectId);
+  if (!project) return { ok: false as const };
+
+  if (sourceNodeId === targetNodeId) {
+    return { ok: false as const, error: "自己ループは作れません" };
+  }
+
+  const existing = await db.query.edges.findFirst({
+    where: and(
+      eq(edges.projectId, projectId),
+      eq(edges.sourceNodeId, sourceNodeId),
+      eq(edges.targetNodeId, targetNodeId),
+    ),
+  });
+  if (existing) {
+    return { ok: false as const, error: "同じリンクが既にあります" };
+  }
+
+  await db
+    .insert(edges)
+    .values({ projectId, sourceNodeId, targetNodeId, polarity, rationale: "" });
+  await touchProject(projectId);
+  return { ok: true as const };
+}
+
 export async function deleteEdge(projectId: string, edgeId: string) {
   const project = await getOwnedProject(projectId);
   if (!project) return { ok: false as const };

--- a/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/diagram-canvas.tsx
@@ -3,6 +3,7 @@
 import {
   Background,
   BackgroundVariant,
+  type Connection,
   Controls,
   type Edge,
   type Node,
@@ -13,9 +14,10 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { TreeStructureIcon } from "@phosphor-icons/react";
+import { PlusIcon, TreeStructureIcon } from "@phosphor-icons/react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { matchArchetypes } from "@/lib/diagram/archetypes";
 import { isCausallyLinked } from "@/lib/diagram/dependencies";
@@ -23,7 +25,12 @@ import { deriveSignedDependencies } from "@/lib/diagram/dependency-polarity";
 import { type LintFinding, lintDiagram } from "@/lib/diagram/lint";
 import { detectLoops, type Loop } from "@/lib/diagram/loops";
 import type { Diagram, DiagramEdge, DiagramNode } from "@/lib/queries/diagrams";
-import { updateNodePosition, updateNodePositions } from "../_actions";
+import {
+  createEdge,
+  createNode,
+  updateNodePosition,
+  updateNodePositions,
+} from "../_actions";
 import { CausalEdge, CausalEdgeMarkers } from "./causal-edge";
 import { DependencyEdge, DependencyEdgeMarkers } from "./dependency-edge";
 import { chooseBulgeSigns } from "./floating-edge-utils";
@@ -52,7 +59,7 @@ export function DiagramCanvas(props: DiagramCanvasProps) {
 }
 
 function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
-  const { fitView } = useReactFlow();
+  const { fitView, screenToFlowPosition } = useReactFlow();
   const { resolvedTheme } = useTheme();
   // resolvedTheme は SSR では不明（常に light 扱い）のため、そのまま使うと
   // ダーク環境で hydration mismatch になる。マウント後にだけ反映する
@@ -64,6 +71,10 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
     | { kind: "node"; node: DiagramNode }
     | { kind: "edge"; edge: DiagramEdge }
     | null
+  >(null);
+
+  const [openPanel, setOpenPanel] = useState<
+    "verification" | "simulation" | null
   >(null);
 
   // 式の依存（情報リンク）のうち、同方向の因果エッジが無いもの。破線描画とループ参加の
@@ -221,6 +232,62 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
     requestAnimationFrame(() => fitView({ padding: 0.25, duration: 600 }));
   }, [diagram, derivedLoopEdges, setNodes, projectId, fitView]);
 
+  const handlePaneDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.classList.contains("react-flow__pane")) return;
+
+      const name = window.prompt("変数の名前を入力してください");
+      if (!name?.trim()) return;
+
+      const position = screenToFlowPosition({
+        x: event.clientX,
+        y: event.clientY,
+      });
+      createNode(projectId, name.trim(), position.x, position.y).then(
+        (result) => {
+          if (!result.ok) {
+            toast.error(result.error ?? "変数を追加できませんでした");
+          }
+        },
+      );
+    },
+    [projectId, screenToFlowPosition],
+  );
+
+  const handleAddNode = useCallback(() => {
+    const name = window.prompt("変数の名前を入力してください");
+    if (!name?.trim()) return;
+
+    const wrapper = document.querySelector(".react-flow__viewport");
+    const rect = wrapper?.closest(".react-flow")?.getBoundingClientRect();
+    const cx = rect ? rect.left + rect.width / 2 : window.innerWidth / 2;
+    const cy = rect ? rect.top + rect.height / 2 : window.innerHeight / 2;
+    const position = screenToFlowPosition({ x: cx, y: cy });
+
+    createNode(projectId, name.trim(), position.x, position.y).then(
+      (result) => {
+        if (!result.ok) {
+          toast.error(result.error ?? "変数を追加できませんでした");
+        }
+      },
+    );
+  }, [projectId, screenToFlowPosition]);
+
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target) return;
+      createEdge(projectId, connection.source, connection.target, "+").then(
+        (result) => {
+          if (!result.ok) {
+            toast.error(result.error ?? "リンクを追加できませんでした");
+          }
+        },
+      );
+    },
+    [projectId],
+  );
+
   return (
     <div className="relative size-full">
       <HighlightContext.Provider value={highlight}>
@@ -235,8 +302,11 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
           fitView
           minZoom={0.25}
           maxZoom={1.75}
-          nodesConnectable={false}
+          nodesConnectable
           deleteKeyCode={null}
+          zoomOnDoubleClick={false}
+          onConnect={handleConnect}
+          onDoubleClick={handlePaneDoubleClick}
           onNodeDragStop={(_, node) => {
             updateNodePosition(
               projectId,
@@ -253,7 +323,10 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
             const found = diagram.edges.find((e) => e.id === edge.id);
             setSelected(found ? { kind: "edge", edge: found } : null);
           }}
-          onPaneClick={() => setSelected(null)}
+          onPaneClick={() => {
+            setSelected(null);
+            setOpenPanel(null);
+          }}
         >
           <Background
             variant={BackgroundVariant.Lines}
@@ -271,8 +344,18 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
       <CausalEdgeMarkers />
       <DependencyEdgeMarkers />
 
-      {diagram.nodes.length > 0 && (
-        <div className="-translate-x-1/2 absolute top-4 left-1/2 z-10">
+      <div className="-translate-x-1/2 absolute top-4 left-1/2 z-10 flex gap-2">
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="gap-1.5 shadow-sm"
+          onClick={handleAddNode}
+        >
+          <PlusIcon size={16} weight="bold" />
+          変数を追加
+        </Button>
+        {diagram.nodes.length > 0 && (
           <Button
             type="button"
             variant="secondary"
@@ -283,26 +366,39 @@ function DiagramCanvasInner({ projectId, diagram }: DiagramCanvasProps) {
             <TreeStructureIcon size={16} weight="bold" />
             整列
           </Button>
-        </div>
-      )}
+        )}
+      </div>
 
       {diagram.nodes.length > 0 && (
         <VerificationPanel
           loopResult={verification.loopResult}
           findings={verification.findings}
           matches={verification.matches}
+          open={openPanel === "verification"}
+          onToggle={() =>
+            setOpenPanel((p) => (p === "verification" ? null : "verification"))
+          }
           onHighlightLoop={highlightLoop}
           onSelectFinding={selectFinding}
         />
       )}
 
-      {diagram.nodes.length > 0 && <SimulationPanel diagram={diagram} />}
+      {diagram.nodes.length > 0 && (
+        <SimulationPanel
+          diagram={diagram}
+          open={openPanel === "simulation"}
+          onToggle={() =>
+            setOpenPanel((p) => (p === "simulation" ? null : "simulation"))
+          }
+        />
+      )}
 
       {diagram.nodes.length === 0 && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <p className="max-w-60 text-center text-muted-foreground text-sm leading-relaxed">
-            対話が進むと、ここに問題の構造が現れます。
-          </p>
+          <div className="max-w-60 text-center text-muted-foreground text-sm leading-relaxed">
+            <p>対話が進むと、ここに問題の構造が現れます。</p>
+            <p className="mt-2 text-xs">ダブルクリックでも変数を追加できます</p>
+          </div>
         </div>
       )}
 

--- a/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/simulation-panel.tsx
@@ -25,6 +25,8 @@ import {
 
 type SimulationPanelProps = {
   diagram: Diagram;
+  open: boolean;
+  onToggle: () => void;
 };
 
 /**
@@ -32,8 +34,11 @@ type SimulationPanelProps = {
  * （構造パネルは左上、inspector は右上）。simulate はクライアントで呼ぶ純粋関数で、結果は保存
  * しない（ループ/lint と同思想）。
  */
-export function SimulationPanel({ diagram }: SimulationPanelProps) {
-  const [open, setOpen] = useState(false);
+export function SimulationPanel({
+  diagram,
+  open,
+  onToggle,
+}: SimulationPanelProps) {
   const [dt, setDt] = useState("1");
   const [steps, setSteps] = useState("20");
   const [result, setResult] = useState<SimResult | null>(null);
@@ -79,10 +84,10 @@ export function SimulationPanel({ diagram }: SimulationPanelProps) {
   };
 
   return (
-    <div className="absolute bottom-3 left-3 flex w-80 flex-col-reverse">
+    <div className="absolute bottom-3 left-3 flex w-80 max-sm:w-[calc(100%-1.5rem)] flex-col-reverse">
       <button
         type="button"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={onToggle}
         className="flex w-fit items-center gap-2 rounded-lg border bg-card/95 px-3 py-1.5 shadow-md backdrop-blur-sm transition-colors hover:bg-accent"
         aria-expanded={open}
       >

--- a/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/variable-node.tsx
@@ -61,8 +61,16 @@ export function VariableNode({ data, selected }: NodeProps) {
   return (
     // ink-in（fill-mode: both）が opacity を保持し続けるため、減光は外側で行う
     <div
-      className={cn("transition-opacity duration-200", dimmed && "opacity-20")}
+      className={cn(
+        "group transition-opacity duration-200",
+        dimmed && "opacity-20",
+      )}
     >
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!size-1.5 !border-muted-foreground/60 !bg-muted-foreground/40 !opacity-0 transition-opacity group-hover:!opacity-100"
+      />
       <div
         className={cn(
           "ink-in border bg-card px-4 py-2 shadow-sm transition-shadow",
@@ -70,12 +78,6 @@ export function VariableNode({ data, selected }: NodeProps) {
           (selected || emphasized) && "border-ring shadow-md",
         )}
       >
-        {/* エッジはフローティング描画のため、ハンドルは接続解決用に不可視で置く */}
-        <Handle
-          type="target"
-          position={Position.Top}
-          className="!opacity-0 !pointer-events-none"
-        />
         <div className="max-w-40 text-center">
           {kind === "flow" && <ValveMark />}
           {kindLabel && (
@@ -90,12 +92,12 @@ export function VariableNode({ data, selected }: NodeProps) {
             </span>
           )}
         </div>
-        <Handle
-          type="source"
-          position={Position.Top}
-          className="!opacity-0 !pointer-events-none"
-        />
       </div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!size-1.5 !border-muted-foreground/60 !bg-muted-foreground/40 !opacity-0 transition-opacity group-hover:!opacity-100"
+      />
     </div>
   );
 }

--- a/src/app/(main)/projects/[projectId]/_components/verification-panel.tsx
+++ b/src/app/(main)/projects/[projectId]/_components/verification-panel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CaretDownIcon, CompassIcon, WarningIcon } from "@phosphor-icons/react";
-import { useState } from "react";
 import type { ArchetypeMatch } from "@/lib/diagram/archetypes";
 import type { LintFinding } from "@/lib/diagram/lint";
 import type { Loop, LoopDetectionResult } from "@/lib/diagram/loops";
@@ -12,6 +11,8 @@ type VerificationPanelProps = {
   loopResult: LoopDetectionResult;
   findings: LintFinding[];
   matches: ArchetypeMatch[];
+  open: boolean;
+  onToggle: () => void;
   onHighlightLoop: (loop: Loop | null) => void;
   onSelectFinding: (finding: LintFinding) => void;
 };
@@ -24,18 +25,19 @@ export function VerificationPanel({
   loopResult,
   findings,
   matches,
+  open,
+  onToggle,
   onHighlightLoop,
   onSelectFinding,
 }: VerificationPanelProps) {
-  const [open, setOpen] = useState(false);
   const { loops, truncated } = loopResult;
   const warningCount = findings.filter((f) => f.severity === "warning").length;
 
   return (
-    <div className="absolute top-3 left-3 flex max-h-[calc(100%-1.5rem)] w-80 flex-col">
+    <div className="absolute top-3 left-3 flex max-h-[calc(100%-1.5rem)] w-80 max-sm:w-[calc(100%-1.5rem)] flex-col">
       <button
         type="button"
-        onClick={() => setOpen((prev) => !prev)}
+        onClick={onToggle}
         className="flex w-fit items-center gap-2 rounded-lg border bg-card/95 px-3 py-1.5 shadow-md backdrop-blur-sm transition-colors hover:bg-accent"
         aria-expanded={open}
       >


### PR DESCRIPTION
## Summary

- キャンバスのダブルクリックまたは「＋ 変数を追加」ボタンで手動ノード作成を追加
- ノードホバー時にハンドルを表示し、ドラッグ接続でエッジを作成できるようにした
- 構造パネル・シミュレーションパネルの排他制御（一方を開くと他方が閉じる）
- キャンバス背景クリックで開いているパネルを閉じる
- モバイル（< sm）でパネル幅が画面からはみ出さないよう `max-sm:w-[calc(100%-1.5rem)]` を適用

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `_actions.ts` | `createNode`, `createEdge` サーバーアクション追加（重複チェック・自己ループ防止付き） |
| `diagram-canvas.tsx` | パネル状態の親管理、ダブルクリック/ボタンによるノード追加、ドラッグ接続 |
| `variable-node.tsx` | ハンドルをホバー時に表示（`group-hover` パターン）、source を Bottom に移動 |
| `verification-panel.tsx` | `open`/`onToggle` prop 化、モバイル幅対応 |
| `simulation-panel.tsx` | `open`/`onToggle` prop 化、モバイル幅対応 |

## Test plan

- [x] キャンバス空白ダブルクリック → ノード生成・リロード後も保持
- [x] ダブルクリック → キャンセル → ノード不生成
- [x] ノード上ダブルクリック → ノード追加が発動しない
- [x] ノードホバー → ハンドル表示
- [x] ハンドルドラッグ → エッジ生成・リロード後も保持
- [x] パネル排他制御（一方開 → 他方閉）
- [x] パネル外クリック → 閉じる
- [x] モバイル幅（375px）でパネル非はみ出し
- [x] `pnpm check` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)