### PR TITLE
fix(login): サインイン失敗時にエラートーストを表示する

### DIFF
--- a/src/app/login/_components/login-button.tsx
+++ b/src/app/login/_components/login-button.tsx
@@ -14,18 +14,22 @@ export function LoginButton() {
     setIsPending(true);
     try {
       // preview（OAuth エミュレータ）は genericOAuth プラグイン経由になる
-      if (isPreview) {
-        await authClient.signIn.oauth2({
-          providerId: "google",
-          callbackURL: "/",
-        });
-      } else {
-        await authClient.signIn.social({
-          provider: "google",
-          callbackURL: "/",
-        });
+      // better-auth クライアントはエラー時に throw せず { error } を返す
+      const { error } = isPreview
+        ? await authClient.signIn.oauth2({
+            providerId: "google",
+            callbackURL: "/",
+          })
+        : await authClient.signIn.social({
+            provider: "google",
+            callbackURL: "/",
+          });
+      if (error) {
+        toast.error("ログインに失敗しました。もう一度お試しください。");
+        setIsPending(false);
       }
     } catch {
+      // ネットワーク断などで fetch 自体が失敗した場合
       toast.error("ログインに失敗しました。もう一度お試しください。");
       setIsPending(false);
     }


### PR DESCRIPTION
## 概要

サインイン API が 500 を返しても画面に何も表示されない問題を修正する。

Fixes #14

## 変更内容

`src/app/login/_components/login-button.tsx` のみ。

- better-auth のクライアントはエラー時に throw せず `{ error }` を返すため、catch 内の `toast.error` が実行されなかった
- 戻り値の `error` を見てトースト表示と `setIsPending(false)` を行うよう変更
- fetch 自体が失敗するケース（ネットワーク断など）向けに catch も残した

## 確認

- `pnpm check` / `pnpm test`（167 件）通過
- DB 未マイグレーション状態（issue と同条件、sign-in API が 500）で実ブラウザ確認: ボタン押下 → エラートースト表示、ボタンの無効化も解除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)